### PR TITLE
Fix build for Android X86

### DIFF
--- a/libvisual/libvisual/lv_cpu.c
+++ b/libvisual/libvisual/lv_cpu.c
@@ -76,7 +76,7 @@ LONG CALLBACK win32_sig_handler_sse(EXCEPTION_POINTERS* ep);
 
 /* The sigill handlers */
 #if defined(VISUAL_ARCH_X86) //x86 (linux katmai handler check thing)
-#if defined(VISUAL_OS_LINUX) && defined(_POSIX_SOURCE)
+#if defined(VISUAL_OS_LINUX) && (defined(_POSIX_SOURCE) || defined(__BIONIC__))
 static void sigill_handler_sse( int signal, struct sigcontext sc )
 {
 	/* Both the "xorps %%xmm0,%%xmm0" and "divps %xmm0,%%xmm1"


### PR DESCRIPTION
Make sure sigill_handler_sse and sigfpe_handler_sse are defined when building for Android x86 checking for **BIONIC** too
