### PR TITLE
goom2k4: Address -Werror=alloc-size-larger-than= issue

### DIFF
--- a/libvisual-plugins/plugins/actor/goom2k4/goomsl.c
+++ b/libvisual-plugins/plugins/actor/goom2k4/goomsl.c
@@ -1272,7 +1272,7 @@ static void gsl_create_fast_iflow(void)
 #else
   InstructionFlow     *iflow     = currentGoomSL->iflow;
   FastInstructionFlow *fastiflow = (FastInstructionFlow*)malloc(sizeof(FastInstructionFlow));
-  fastiflow->mallocedInstr = calloc(number*16, sizeof(FastInstruction));
+  fastiflow->mallocedInstr = calloc(number, 16*sizeof(FastInstruction));
   /* fastiflow->instr = (FastInstruction*)(((int)fastiflow->mallocedInstr) + 16 - (((int)fastiflow->mallocedInstr)%16)); */
   fastiflow->instr = (FastInstruction*)fastiflow->mallocedInstr;
   fastiflow->number = number;


### PR DESCRIPTION
Related: https://github.com/Libvisual/libvisual/issues/80#issuecomment-565579867

@svgmuc does this fix the issue for you?

Error was:
```
[..]/libvisual-plugins/plugins/actor/goom2k4/goomsl.c:1275:30: error: argument 1 range [18446744071562067968, 18446744073709551615] exceeds
 maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
   fastiflow->mallocedInstr = calloc(number*16, sizeof(FastInstruction));
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
