### PR TITLE
lv_cpu: Use Rip if on 64-bit Windows

### DIFF
--- a/libvisual/libvisual/lv_cpu.c
+++ b/libvisual/libvisual/lv_cpu.c
@@ -133,7 +133,11 @@ static void sigfpe_handler_sse (int signal, struct sigcontext sc)
 LONG CALLBACK win32_sig_handler_sse (EXCEPTION_POINTERS* ep)
 {
 	if (ep->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
+#ifdef _AMD64_
+		ep->ContextRecord->Rip +=3;
+#else
 		ep->ContextRecord->Eip +=3;
+#endif
 		cpu_caps.hasSSE = FALSE;
 		return EXCEPTION_CONTINUE_EXECUTION;
 	}


### PR DESCRIPTION
Fixes #77