### PR TITLE
[GitHub Actions] [Windows] Uninstall mingw-w64-x86_64-libgccjit to resolve conflicts

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           # We're deleting these packages because trying to upgrade to the latest bugfix version of gcc without doing a Suu will result in
           # errors such as unmet dependencies, removing them would be much faster than upgrading them as well.
-          pacman -R --noconfirm mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-libgfortran
+          pacman -R --noconfirm mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-libgfortran mingw-w64-x86_64-libgccjit
           pacman -Suu --needed --ask=20 --noconfirm
 
       - name: Install packages


### PR DESCRIPTION
The CI started failing, e.g. see https://github.com/Libvisual/libvisual/runs/4575127948?check_suite_focus=true#step:7:21

The symptom was:
```
[..]
looking for conflicting packages...
error: failed to prepare transaction (could not satisfy dependencies)
:: installing mingw-w64-x86_64-gcc (11.2.0-5) breaks dependency 'mingw-w64-x86_64-gcc=11.2.0-4' required by mingw-w64-x86_64-libgccjit
```