### PR TITLE
[0.4.x] libvisual + libvisual-plugins: Address Clang 16 warning -Wimplicit-function-declaration

### DIFF
--- a/libvisual-plugins/plugins/actor/oinksie/gfx-scope.c
+++ b/libvisual-plugins/plugins/actor/oinksie/gfx-scope.c
@@ -21,6 +21,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include <math.h>
+
 #include "common.h"
 #include "screen.h"
 #include "audio.h"

--- a/libvisual-plugins/plugins/actor/pseudotoad_flower/notch.c
+++ b/libvisual-plugins/plugins/actor/pseudotoad_flower/notch.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 

--- a/libvisual/libvisual/lv_libvisual.c
+++ b/libvisual/libvisual/lv_libvisual.c
@@ -39,6 +39,7 @@
 #include "lv_log.h"
 #include "lv_param.h"
 #include "lv_thread.h"
+#include "lv_cpu.h"
 #include "config.h"
 
 

--- a/libvisual/libvisual/lv_math.c
+++ b/libvisual/libvisual/lv_math.c
@@ -29,6 +29,7 @@
 #include <math.h>
 
 #include "lv_bits.h"
+#include "lv_cpu.h"
 #include "lv_math.h"
 
 /* This file is getting big and bloated because of the large chunks of simd code. When all is in place we'll take a serious

--- a/libvisual/libvisual/lv_transform.c
+++ b/libvisual/libvisual/lv_transform.c
@@ -41,6 +41,8 @@ static int transform_dtor (VisObject *object);
 
 static VisTransformPlugin *get_transform_plugin (VisTransform *transform);
 
+int visual_transform_init (VisTransform *transform, const char *transformname);
+
 
 static int transform_dtor (VisObject *object)
 {


### PR DESCRIPTION
First raised at https://bugs.gentoo.org/871015

The precise errors fixed are:

GCC's view:
```
libvisual/lv_libvisual.c:315:9: error: implicit declaration of function 'visual_cpu_initialize'; did you mean 'visual_mem_initialize'? [-Werror=implicit-function-declaration]
libvisual/lv_transform.c:154:9: error: implicit declaration of function 'visual_transform_init'; did you mean 'visual_transform_new'? [-Werror=implicit-function-declaration]
libvisual/lv_math.c:66:13: error: implicit declaration of function 'visual_cpu_get_sse' [-Werror=implicit-function-declaration]
libvisual/lv_math.c:112:20: error: implicit declaration of function 'visual_cpu_get_3dnow' [-Werror=implicit-function-declaration]
```

Clang 16's view:
```
../../libvisual/lv_libvisual.c:315:2: error: call to undeclared function 'visual_cpu_initialize'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        visual_cpu_initialize ();
        ^
../../libvisual/lv_libvisual.c:315:2: note: did you mean 'visual_mem_initialize'?
../../libvisual/lv_mem.h:78:5: note: 'visual_mem_initialize' declared here
int visual_mem_initialize (void);
    ^
../../libvisual/lv_math.c:66:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
../../libvisual/lv_transform.c:154:2: error: call to undeclared function 'visual_transform_init'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        visual_transform_init (transform, transformname);
        ^
../../libvisual/lv_transform.c:154:2: note: did you mean 'visual_transform_new'?
../../libvisual/lv_transform.c:148:15: note: 'visual_transform_new' declared here
VisTransform *visual_transform_new (const char *transformname)
              ^
../../libvisual/lv_math.c:112:13: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        } else if (visual_cpu_get_3dnow ()) {
                   ^
../../libvisual/lv_math.c:190:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
../../libvisual/lv_math.c:236:13: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        } else if (visual_cpu_get_3dnow ()) {
                   ^
../../libvisual/lv_math.c:314:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
../../libvisual/lv_math.c:360:13: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        } else if (visual_cpu_get_3dnow ()) {
                   ^
../../libvisual/lv_math.c:429:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
../../libvisual/lv_math.c:470:13: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        } else if (visual_cpu_get_3dnow ()) {
                   ^
../../libvisual/lv_math.c:535:6: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_3dnow ()) {
            ^
../../libvisual/lv_math.c:599:6: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_3dnow ()) {
            ^
../../libvisual/lv_math.c:664:6: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_3dnow ()) {
            ^
../../libvisual/lv_math.c:734:6: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_3dnow ()) {
            ^
../../libvisual/lv_math.c:813:6: error: call to undeclared function 'visual_cpu_get_3dnow'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_3dnow ()) {
            ^
../../libvisual/lv_math.c:895:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
../../libvisual/lv_math.c:960:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
../../libvisual/lv_math.c:1035:6: error: call to undeclared function 'visual_cpu_get_sse'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (visual_cpu_get_sse () && n >= 16) {
            ^
```
