### PR TITLE
[0.4.x] libvisual: Allow strict aliasing (-Werror=strict-aliasing)

### DIFF
--- a/libvisual/libvisual/lv_color.c
+++ b/libvisual/libvisual/lv_color.c
@@ -270,15 +270,18 @@ uint32_t visual_color_to_uint32 (VisColor *color)
 
 uint16_t visual_color_to_uint16 (VisColor *color)
 {
-	_color16 colors;
+	union {
+	    _color16 channels;
+	    uint16_t raw;
+	} colors;
 
 	visual_log_return_val_if_fail (color != NULL, 0);
 
-	colors.r = color->r >> 2;
-	colors.g = color->g >> 3;
-	colors.b = color->b >> 2;
+	colors.channels.r = color->r >> 2;
+	colors.channels.g = color->g >> 3;
+	colors.channels.b = color->b >> 2;
 
-	return *((uint16_t *) &colors);
+	return colors.raw;
 }
 
 VisColor *visual_color_black ()


### PR DESCRIPTION
First raised at https://bugs.gentoo.org/859922

Note that `master` already has that problem fixed.