### PR TITLE
[0.4.x] libvisual-plugins: Fixes configure so that lv_analyzer actually gets built

### DIFF
--- a/libvisual-plugins/configure.ac
+++ b/libvisual-plugins/configure.ac
@@ -361,7 +361,7 @@ AC_ARG_ENABLE([analyzer],
   [ENABLE_ANALYZER=$enableval],
   [ENABLE_ANALYZER=yes])
 
-if test "$ENABLE_ANALYZER" = xyes; then
+if test "$ENABLE_ANALYZER" = "yes"; then
   build_actor_plugins="$build_actor_plugins lv_analyzer"
 fi
 


### PR DESCRIPTION
See https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/40_lv_analyzer_build_fix.patch/