### PR TITLE
[0.4.x] libvisual-plugins: Fix -Wnarrowing compile error (GCC 12)

### DIFF
--- a/libvisual-plugins/plugins/actor/G-Force/Common/EgCommon.h
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/EgCommon.h
@@ -3,11 +3,6 @@
 
 #include <libmfl.h>
 
-	#ifndef true
-	#define true -1
-	#define false 0
-	#endif
-
 	struct Rect {
 		short left, top, right, bottom;
 	};


### PR DESCRIPTION
In Gentoo: https://bugs.gentoo.org/840514