### PR TITLE
libvisual-plugins: Mass-fix typo "transparant"

### DIFF
--- a/libvisual-plugins/ChangeLog
+++ b/libvisual-plugins/ChangeLog
@@ -760,7 +760,7 @@
 
 	* plugins/actor/lv_gltest/actor_lv_gltest.c
 	(lv_gltest_init): Add a parameter for enabling
-	transparant bars, and enable this by default.
+	transparent bars, and enable this by default.
 
 	(lv_gltest_events): Listen to the new parameter.
 

--- a/libvisual-plugins/README
+++ b/libvisual-plugins/README
@@ -15,7 +15,7 @@ libvisual can be drawn everywhere. That is but not limited
 to: ascii art, sdl, on gl object as a surface , alpha blended
 or just, anywhere.
 
-Libvisual also provides complete easy to use transparant
+Libvisual also provides complete easy to use transparent
 depth transformation, so that even when the display
 isn't supported by the plugin, libvisual will make
 it suite. Besides using libvisual for rendering your

--- a/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.cpp
+++ b/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.cpp
@@ -160,9 +160,9 @@ int lv_dancingparticles_events (VisPluginData *plugin, VisEventQueue *events)
 				param = static_cast<VisParam *> (ev.event.param.param);
 
 				if (visual_param_has_name (param, "transparent_bars")) {
-					priv->transparant = visual_param_get_value_bool (param);
+					priv->transparent = visual_param_get_value_bool (param);
 
-					if (priv->transparant == FALSE)
+					if (priv->transparent == FALSE)
 						glDisable (GL_BLEND);
 					else
 						glEnable (GL_BLEND);

--- a/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.h
+++ b/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.h
@@ -28,7 +28,7 @@
 
 
 typedef struct {
-	int transparant;
+	int transparent;
 	int titleHasChanged;
 } DancingParticlesPrivate;
 

--- a/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
+++ b/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
@@ -49,7 +49,7 @@ typedef struct {
 	GLfloat z_speed;
 	GLfloat heights[16][16];
 
-	int transparant;
+	int transparent;
 } GLtestPrivate;
 
 static int         lv_gltest_init        (VisPluginData *plugin);
@@ -215,9 +215,9 @@ static int lv_gltest_events (VisPluginData *plugin, VisEventQueue *events)
 				param = ev.event.param.param;
 
 				if (visual_param_has_name (param, "transparent_bars")) {
-					priv->transparant = visual_param_get_value_bool (param);
+					priv->transparent = visual_param_get_value_bool (param);
 
-					if (priv->transparant == FALSE)
+					if (priv->transparent == FALSE)
 						glDisable (GL_BLEND);
 					else
 						glEnable (GL_BLEND);


### PR DESCRIPTION
Idea is from https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/95_fix_spelling.patch/ but this is for `master` not `0.4.x` and goes a bit further. Note that "transparant" with "a" is a thing while "transparent" with "e" is an adjective.