### PR TITLE
[0.4.x] libvisual-plugins: Mass-fix typo "transparant"

### DIFF
--- a/libvisual-plugins/ChangeLog
+++ b/libvisual-plugins/ChangeLog
@@ -754,7 +754,7 @@
 
 	* plugins/actor/lv_gltest/actor_lv_gltest.c
 	(lv_gltest_init): Add a parameter for enabling
-	transparant bars, and enable this by default.
+	transparent bars, and enable this by default.
 
 	(lv_gltest_events): Listen to the new parameter.
 

--- a/libvisual-plugins/README
+++ b/libvisual-plugins/README
@@ -15,7 +15,7 @@ libvisual can be drawn everywhere. That is but not limited
 to: ascii art, sdl, on gl object as a surface , alpha blended
 or just, anywhere.
 
-Libvisual also provides complete easy to use transparant
+Libvisual also provides complete easy to use transparent
 depth transformation, so that even when the display
 isn't supported by the plugin, libvisual will make
 it suite. Besides using libvisual for rendering your

--- a/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.cpp
+++ b/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.cpp
@@ -99,7 +99,7 @@ extern "C" int lv_dancingparticles_init (VisPluginData *plugin)
 	VisParamContainer *paramcontainer = visual_plugin_get_params (plugin);
 	
 	static VisParamEntry params[] = {
-		VISUAL_PARAM_LIST_ENTRY_INTEGER ("transparant bars",	TRUE),
+		VISUAL_PARAM_LIST_ENTRY_INTEGER ("transparent bars",	TRUE),
 		VISUAL_PARAM_LIST_END
 	};
 	
@@ -116,7 +116,7 @@ extern "C" int lv_dancingparticles_init (VisPluginData *plugin)
 	visual_param_container_add_many (paramcontainer, params);
 
 	checkbox = visual_ui_checkbox_new ("Transparant bars", TRUE);
-	visual_ui_mutator_set_param (VISUAL_UI_MUTATOR (checkbox), visual_param_container_get (paramcontainer, "transparant bars"));
+	visual_ui_mutator_set_param (VISUAL_UI_MUTATOR (checkbox), visual_param_container_get (paramcontainer, "transparent bars"));
 
 	visual_plugin_set_userinterface (plugin, checkbox);
 
@@ -185,10 +185,10 @@ extern "C" int lv_dancingparticles_events (VisPluginData *plugin, VisEventQueue 
 			case VISUAL_EVENT_PARAM:
 				param = static_cast<VisParamEntry *> (ev.event.param.param);
 
-				if (visual_param_entry_is (param, "transparant bars")) {
-					priv->transparant = visual_param_entry_get_integer (param);
+				if (visual_param_entry_is (param, "transparent bars")) {
+					priv->transparent = visual_param_entry_get_integer (param);
 
-					if (priv->transparant == FALSE)
+					if (priv->transparent == FALSE)
 						glDisable (GL_BLEND);
 					else
 						glEnable (GL_BLEND);

--- a/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.h
+++ b/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.h
@@ -28,7 +28,7 @@
 
 
 typedef struct {
-	int transparant;
+	int transparent;
 	int titleHasChanged;
 } DancingParticlesPrivate;
 

--- a/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
+++ b/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
@@ -51,7 +51,7 @@ typedef struct {
 	GLfloat z_speed;
 	GLfloat heights[16][16];
 
-	int transparant;
+	int transparent;
 } GLtestPrivate;
 
 int lv_gltest_init (VisPluginData *plugin);
@@ -115,7 +115,7 @@ int lv_gltest_init (VisPluginData *plugin)
 	VisParamContainer *paramcontainer = visual_plugin_get_params (plugin);
 	
 	static VisParamEntry params[] = {
-		VISUAL_PARAM_LIST_ENTRY_INTEGER ("transparant bars",	TRUE),
+		VISUAL_PARAM_LIST_ENTRY_INTEGER ("transparent bars",	TRUE),
 		VISUAL_PARAM_LIST_END
 	};
 	
@@ -134,7 +134,7 @@ int lv_gltest_init (VisPluginData *plugin)
 	visual_param_container_add_many (paramcontainer, params);
 
 	checkbox = visual_ui_checkbox_new (_("Transparant bars"), TRUE);
-	visual_ui_mutator_set_param (VISUAL_UI_MUTATOR (checkbox), visual_param_container_get (paramcontainer, "transparant bars"));
+	visual_ui_mutator_set_param (VISUAL_UI_MUTATOR (checkbox), visual_param_container_get (paramcontainer, "transparent bars"));
 
 	visual_plugin_set_userinterface (plugin, checkbox);
 
@@ -240,10 +240,10 @@ int lv_gltest_events (VisPluginData *plugin, VisEventQueue *events)
 			case VISUAL_EVENT_PARAM:
 				param = ev.event.param.param;
 
-				if (visual_param_entry_is (param, "transparant bars")) {
-					priv->transparant = visual_param_entry_get_integer (param);
+				if (visual_param_entry_is (param, "transparent bars")) {
+					priv->transparent = visual_param_entry_get_integer (param);
 
-					if (priv->transparant == FALSE)
+					if (priv->transparent == FALSE)
 						glDisable (GL_BLEND);
 					else
 						glEnable (GL_BLEND);


### PR DESCRIPTION
Similar to #114 but for 0.4.x

Idea is from https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/95_fix_spelling.patch/ but this patch goes a bit further. Note that "transparant" with "a" is a thing while "transparent" with "e" is an adjective.