### PR TITLE
[0.4.x] libvisual: Fix typo "succesful"

### DIFF
--- a/libvisual/libvisual/lv_error.c
+++ b/libvisual/libvisual/lv_error.c
@@ -106,7 +106,7 @@ static const char *__lv_error_human_readable[] = {
 	[VISUAL_ERROR_MORPH_NULL] =			N_("VisMorph is NULL"),
 	[VISUAL_ERROR_MORPH_PLUGIN_NULL] =		N_("VisMorph it's plugin is NULL"),
 
-	[VISUAL_ERROR_OS_SCHED] =			N_("The scheduler related call wasn't succesful."),
+	[VISUAL_ERROR_OS_SCHED] =			N_("The scheduler related call wasn't successful."),
 	[VISUAL_ERROR_OS_SCHED_NOT_SUPPORTED] =		N_("Scheduler operations are not supported on the platform."),
 
 	[VISUAL_ERROR_PALETTE_NULL] =			N_("VisPalette is NULL"),

--- a/libvisual/libvisual/lv_error.h
+++ b/libvisual/libvisual/lv_error.h
@@ -127,7 +127,7 @@ enum {
 	VISUAL_ERROR_MORPH_PLUGIN_NULL,			/**< The VisMorphPlugin is NULL. */
 
 	/* Error entries for the VisOS system */
-	VISUAL_ERROR_OS_SCHED,				/**< The scheduler related call wasn't succesful. */
+	VISUAL_ERROR_OS_SCHED,				/**< The scheduler related call wasn't successful. */
 	VISUAL_ERROR_OS_SCHED_NOT_SUPPORTED,		/**< Scheduler operations are not supported on the platform. */
 
 	/* Error entries for the VisPalette system */

--- a/libvisual/po/es_AR.po
+++ b/libvisual/po/es_AR.po
@@ -430,7 +430,7 @@ msgid "VisMorph it's plugin is NULL"
 msgstr ""
 
 #: libvisual/lv_error.c:109
-msgid "The scheduler related call wasn't succesful."
+msgid "The scheduler related call wasn't successful."
 msgstr ""
 
 #: libvisual/lv_error.c:110

--- a/libvisual/po/es_ES.po
+++ b/libvisual/po/es_ES.po
@@ -430,7 +430,7 @@ msgid "VisMorph it's plugin is NULL"
 msgstr ""
 
 #: libvisual/lv_error.c:109
-msgid "The scheduler related call wasn't succesful."
+msgid "The scheduler related call wasn't successful."
 msgstr ""
 
 #: libvisual/lv_error.c:110

--- a/libvisual/po/libvisual-0.4.pot
+++ b/libvisual/po/libvisual-0.4.pot
@@ -416,7 +416,7 @@ msgid "VisMorph it's plugin is NULL"
 msgstr ""
 
 #: libvisual/lv_error.c:109
-msgid "The scheduler related call wasn't succesful."
+msgid "The scheduler related call wasn't successful."
 msgstr ""
 
 #: libvisual/lv_error.c:110


### PR DESCRIPTION
From https://sources.debian.org/patches/libvisual/0.4.0-18/50_fix-spelling-errors.patch/