### PR TITLE
[0.4.x] libvisual: Fix typo "indentical"

### DIFF
--- a/libvisual/libvisual/lv_error.c
+++ b/libvisual/libvisual/lv_error.c
@@ -198,7 +198,7 @@ static const char *__lv_error_human_readable[] = {
 	[VISUAL_ERROR_VIDEO_INVALID_SCALE_METHOD] =	N_("Invalid scale method given"),
 	[VISUAL_ERROR_VIDEO_INVALID_ROTATE] =		N_("Invalid rotate degrees given"),
 	[VISUAL_ERROR_VIDEO_OUT_OF_BOUNDS] =		N_("Given coordinates are out of bounds"),
-	[VISUAL_ERROR_VIDEO_NOT_INDENTICAL] =		N_("Given VisVideos are not indentical"),
+	[VISUAL_ERROR_VIDEO_NOT_INDENTICAL] =		N_("Given VisVideos are not identical"),
 	[VISUAL_ERROR_VIDEO_NOT_TRANSFORMED] =		N_("VisVideo is not depth transformed as requested")
 };
 

--- a/libvisual/libvisual/lv_error.h
+++ b/libvisual/libvisual/lv_error.h
@@ -231,7 +231,7 @@ enum {
 	VISUAL_ERROR_VIDEO_INVALID_SCALE_METHOD,	/**< The VisVideoScaleMethod argument is not valid. */
 	VISUAL_ERROR_VIDEO_INVALID_ROTATE,		/**< The VisVideoRotateDegrees argument is not valid. */
 	VISUAL_ERROR_VIDEO_OUT_OF_BOUNDS,		/**< The X or Y value are greater than the VisVideo it's dimension. */
-	VISUAL_ERROR_VIDEO_NOT_INDENTICAL,		/**< The two VisVideo their configuration are not indentical. */
+	VISUAL_ERROR_VIDEO_NOT_INDENTICAL,		/**< The two VisVideo their configuration are not identical. */
 	VISUAL_ERROR_VIDEO_NOT_TRANSFORMED,		/**< Could not depth transform a VisVideo. */
 
 	VISUAL_ERROR_LIST_END				/**< Last entry, to check against for the number of errors. */

--- a/libvisual/po/es_AR.po
+++ b/libvisual/po/es_AR.po
@@ -774,7 +774,7 @@ msgid "Given coordinates are out of bounds"
 msgstr "Las coordenadas dadas están fuera de los límites"
 
 #: libvisual/lv_error.c:201
-msgid "Given VisVideos are not indentical"
+msgid "Given VisVideos are not identical"
 msgstr "Los VisVideos dados no son idénticos"
 
 #: libvisual/lv_error.c:202

--- a/libvisual/po/es_ES.po
+++ b/libvisual/po/es_ES.po
@@ -774,7 +774,7 @@ msgid "Given coordinates are out of bounds"
 msgstr "Las coordenadas dadas están fuera de los límites"
 
 #: libvisual/lv_error.c:201
-msgid "Given VisVideos are not indentical"
+msgid "Given VisVideos are not identical"
 msgstr "Los VisVideos dados no son idénticos"
 
 #: libvisual/lv_error.c:202

--- a/libvisual/po/libvisual-0.4.pot
+++ b/libvisual/po/libvisual-0.4.pot
@@ -728,7 +728,7 @@ msgid "Given coordinates are out of bounds"
 msgstr ""
 
 #: libvisual/lv_error.c:201
-msgid "Given VisVideos are not indentical"
+msgid "Given VisVideos are not identical"
 msgstr ""
 
 #: libvisual/lv_error.c:202


### PR DESCRIPTION
Inspired by https://sources.debian.org/patches/libvisual/0.4.0-18/80_fix_spelling.patch/ but taken further