### PR TITLE
[0.4.x] libvisual: Fix detection of pkg-config for cross-compilation

### DIFF
--- a/libvisual/configure.ac
+++ b/libvisual/configure.ac
@@ -98,8 +98,8 @@ AC_LIBTOOL_WIN32_DLL
 AC_LIBTOOL_DLOPEN
 AC_PROG_LIBTOOL
 
-AC_PATH_PROG(PKG_CONFIG, [pkg-config], [no])
-if test x$PKG_CONFIG = xno ; then
+PKG_PROG_PKG_CONFIG
+if test x$PKG_CONFIG = x ; then
   AC_MSG_WARN([*** pkg-config not found. See http://www.freedesktop.org/software/pkgconfig/.
 	       *** You will need pkg-config to compile against Libvisual Library])
 fi

--- a/libvisual/configure.ac
+++ b/libvisual/configure.ac
@@ -100,8 +100,8 @@ AC_PROG_LIBTOOL
 
 PKG_PROG_PKG_CONFIG
 if test x$PKG_CONFIG = x ; then
-  AC_MSG_WARN([*** pkg-config not found. See http://www.freedesktop.org/software/pkgconfig/.
-	       *** You will need pkg-config to compile against Libvisual Library])
+  AC_MSG_ERROR([*** pkg-config not found. See http://www.freedesktop.org/software/pkgconfig/.
+                  *** You will need pkg-config to compile against Libvisual Library])
 fi
 if $PKG_CONFIG --atleast-pkgconfig-version 0.14 ; then
   :


### PR DESCRIPTION
Inspired by https://sources.debian.org/patches/libvisual/0.4.0-18/95_fix-FTCBFS.patch/ but taken further