### PR TITLE
[0.4.x] libvisual-plugins: Fix nastyfft blocker

### DIFF
--- a/libvisual-plugins/plugins/actor/nastyfft/actor_nastyfft.c
+++ b/libvisual-plugins/plugins/actor/nastyfft/actor_nastyfft.c
@@ -80,7 +80,7 @@ const VisPluginInfo *get_plugin_info (int *count)
 		.vidoptions.depth = VISUAL_VIDEO_DEPTH_GL
 	}};
 
-	static const VisPluginInfo info[] = {{
+	static VisPluginInfo info[] = {{
 		.type = VISUAL_PLUGIN_TYPE_ACTOR,
 
 		.plugname = N_("nastyfft"),


### PR DESCRIPTION
From https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/70_no-const-vispluginfo-in-nastyfft.patch/