### PR TITLE
[0.4.x] libvisual-plugins: Make translations work properly

### DIFF
--- a/libvisual-plugins/Makefile.am
+++ b/libvisual-plugins/Makefile.am
@@ -1,5 +1,7 @@
 ## Process this file with automake to generate a Makefile.in
 
+ACLOCAL_AMFLAGS = -I m4
+
 SUBDIRS = plugins po
 
 EXTRA_DIST = libvisual-plugins.spec gettext.h po/Makevars.in

--- a/libvisual-plugins/configure.ac
+++ b/libvisual-plugins/configure.ac
@@ -13,6 +13,7 @@ AM_INIT_AUTOMAKE([1.7.0 dist-bzip2])
 
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADER([config.h])
+AC_CONFIG_MACRO_DIR([m4])
 
 m4_define([libvisual_required_version], [lv_plugins_version])
 m4_define([esound_required_version], [0.2.28])


### PR DESCRIPTION
```console
$ autoreconf --install --verbose |& grep -F m4 | head -n2
libtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([m4])' to configure.ac,
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
```

From https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/50_fix_po.patch/