### PR TITLE
[0.4.x] libvisual-plugins: Address GCC/Clang warning -Wpointer-to-int-cast

### DIFF
--- a/libvisual-plugins/plugins/input/mplayer/input_mplayer.c
+++ b/libvisual-plugins/plugins/input/mplayer/input_mplayer.c
@@ -155,7 +155,7 @@ int inp_mplayer_init( VisPluginData *plugin )
 
 	priv->mmap_area = mmap( 0, sizeof( mplayer_data_t ),
 			PROT_READ, MAP_SHARED, priv->fd, 0 );
-	visual_log_return_val_if_fail( (int)priv->mmap_area != -1, -1 );
+	visual_log_return_val_if_fail( priv->mmap_area != (void *)-1, -1 );
 
 	if ( priv->mmap_area->nch == 0 )
 	{
@@ -179,7 +179,7 @@ int inp_mplayer_init( VisPluginData *plugin )
 	priv->mmap_area = mremap( priv->mmap_area, sizeof( mplayer_data_t ),
 			sizeof( mplayer_data_t ) + priv->mmap_area->bs,
 			0 );
-	if ( (int)priv->mmap_area == -1 )
+	if ( priv->mmap_area == (void *)-1 )
 	{
 		visual_log( VISUAL_LOG_CRITICAL, 
 				_("Could not mremap() area from file '%s' " \


### PR DESCRIPTION
> ```
> [..]/plugins/input/mplayer/input_mplayer.c:158:33: error: cast to smaller integer type 'int' from 'mplayer_data_t *' [-Werror,-Wpointer-to-int-cast]
>         visual_log_return_val_if_fail( (int)priv->mmap_area != -1, -1 );
>                                        ^~~~~~~~~~~~~~~~~~~~
> [..]/plugins/input/mplayer/input_mplayer.c:182:7: error: cast to smaller integer type 'int' from 'mplayer_data_t *' [-Werror,-Wpointer-to-int-cast]
>         if ( (int)priv->mmap_area == -1 )
>              ^~~~~~~~~~~~~~~~~~~~
> ```

Alternative to half of https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/90_fix_some_gcc_warnings.patch/