### PR TITLE
[0.4.x] libvisual-plugins: Address GCC/Clang warning -Wformat

### DIFF
--- a/libvisual-plugins/plugins/input/mplayer/input_mplayer.c
+++ b/libvisual-plugins/plugins/input/mplayer/input_mplayer.c
@@ -183,7 +183,7 @@ int inp_mplayer_init( VisPluginData *plugin )
 	{
 		visual_log( VISUAL_LOG_CRITICAL, 
 				_("Could not mremap() area from file '%s' " \
-					" (%p from %d to %d bytes): %s"),
+					" (%p from %zu to %zu bytes): %s"),
 				priv->sharedfile, 
 				priv->mmap_area, sizeof( mplayer_data_t ),
 				sizeof( mplayer_data_t ) + priv->mmap_area->bs,


### PR DESCRIPTION
> ```
> [..]/plugins/input/mplayer/input_mplayer.c:190:22: error: format specifies type 'int' but the argument has type 'unsigned long' [-Werror,-Wformat]
>                                 priv->mmap_area, sizeof( mplayer_data_t ),
>                                                  ^~~~~~~~~~~~~~~~~~~~~~~~
> [..]/plugins/input/mplayer/input_mplayer.c:191:5: error: format specifies type 'int' but the argument has type 'unsigned long' [-Werror,-Wformat]
>                                 sizeof( mplayer_data_t ) + priv->mmap_area->bs,
>                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> ```

Alternative to half of https://sources.debian.org/patches/libvisual-plugins/1:0.4.0%2Bdfsg1-10/90_fix_some_gcc_warnings.patch/ ; other half is #126 