### PR TITLE
[0.4.x] libvisual-plugins: Address Clang 16 warning -Wregister

### DIFF
--- a/libvisual-plugins/plugins/actor/G-Force/Common/GeneralTools/UtilStr.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/GeneralTools/UtilStr.cpp
@@ -134,7 +134,7 @@ char* UtilStr::getCStr() const {
 
 
 void UtilStr::Append( const  char* inCStr ) {
-	register unsigned long i = 0;
+	unsigned long i = 0;
 
 	if ( inCStr ) {
 		while( inCStr[ i ] != '\0' ) 
@@ -397,8 +397,8 @@ void UtilStr::Insert( unsigned long inPos, const char* inSrce, long inBytes ) {
 void UtilStr::Move( void* inDest, const void* inSrce, unsigned long inNumBytes ) {
 
 	if ( inNumBytes <= 64 ) {
-		register unsigned char* dest = (unsigned char*) inDest;
-		register unsigned char* srce = (unsigned char*) inSrce;
+		unsigned char* dest = (unsigned char*) inDest;
+		unsigned char* srce = (unsigned char*) inSrce;
 		if ( srce > dest )
 			while ( inNumBytes > 0 ) {
 				*dest = *srce;

--- a/libvisual-plugins/plugins/actor/G-Force/Common/UI/DrawXX.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/UI/DrawXX.cpp
@@ -414,10 +414,10 @@ void PixPort::_CrossBlur( char* inSrce, int inWidth, int inHeight, int inBytesPe
 
 
 void PixPort::_BoxBlur( char* inSrce, char* inDest, int inBoxWidth, int inWidth, int inHeight, int inSrceRowWidth, int inDestRowWidth, unsigned long* b, unsigned long inBackColor ) {
-	register unsigned long* bEnd;
-	register char *dest;
-	register unsigned long b1R, b1G, b1B, b2R, b2G, b2B, b3R, b3G, b3B, val, box9W, i, numerator;
-	register int x, half, useWidth;
+	unsigned long* bEnd;
+	char *dest;
+	unsigned long b1R, b1G, b1B, b2R, b2G, b2B, b3R, b3G, b3B, val, box9W, i, numerator;
+	int x, half, useWidth;
 	
 	i = inBoxWidth * inBoxWidth * inBoxWidth;
 	numerator = ( 1 << DENOM_SHIFT ) / ( i );
@@ -492,9 +492,9 @@ void PixPort::_BoxBlur( char* inSrce, char* inDest, int inBoxWidth, int inWidth,
 this modification to BoxBlur only blurs the x row
 void PixPort::_BoxBlur( char* inSrce, char*, int inBoxWidth, int inWidth, int inHeight, int inSrceRowWidth, int, char* b, unsigned long inBackColor ) {
 
-	register char *bEnd;
-	register unsigned long b1R, b1G, b1B, b2R, b2G, b2B, b3R, b3G, b3B, val, box9W, i, denom;
-	register int x, half, useWidth;
+	char *bEnd;
+	unsigned long b1R, b1G, b1B, b2R, b2G, b2B, b3R, b3G, b3B, val, box9W, i, denom;
+	int x, half, useWidth;
 	
 	
 	denom = inBoxWidth * inBoxWidth * inBoxWidth;

--- a/libvisual-plugins/plugins/actor/G-Force/Common/io/CEgIStream.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/io/CEgIStream.cpp
@@ -26,7 +26,7 @@ CEgIStream::CEgIStream( unsigned short int inBufSize ) {
 
 
 long CEgIStream::GetLong() {		
-	register unsigned long c, n = GetByte();
+	unsigned long c, n = GetByte();
 	
 	c = GetByte();
 	n = n | ( c << 8 );
@@ -49,7 +49,7 @@ float CEgIStream::GetFloat() {
 
 
 short int CEgIStream::GetShort() {
-	register unsigned long n = GetByte();
+	unsigned long n = GetByte();
 	
 	return (short int) ((GetByte() << 8) | n);
 }
@@ -59,7 +59,7 @@ short int CEgIStream::GetShort() {
 
 
 unsigned char CEgIStream::GetByte() {
-	register unsigned char c;
+	unsigned char c;
 	
 	if ( mIsTied ) {
 		if ( mPos != 0 ) {
@@ -83,7 +83,7 @@ unsigned char CEgIStream::GetByte() {
 
 
 unsigned char CEgIStream::PeekByte() {
-	register unsigned char c;
+	unsigned char c;
 	
 	if ( mIsTied ) {
 		if ( mPos != 0 )

--- a/libvisual-plugins/plugins/actor/G-Force/Common/math/ExprVirtualMachine.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/math/ExprVirtualMachine.cpp
@@ -237,8 +237,8 @@ void ExprVirtualMachine::PrepForExecution() {
 // 24-31:	Dest Register number
 								
 float ExprVirtualMachine::Execute/*_Inline*/() {
-	register float	FR0, FR1, FR2, FR3, FR4, FR5, FR6, FR7; // FR8, FR9, FR10, FR11, FR12, FR13, FR14, FR15;
-	register float	v1, v2;
+	float	FR0, FR1, FR2, FR3, FR4, FR5, FR6, FR7; // FR8, FR9, FR10, FR11, FR12, FR13, FR14, FR15;
+	float	v1, v2;
 	const char*	PC	= mPCStart;
 	const char*	end	= mPCEnd;
 	unsigned long	inst, opcode, subop, size, i, r2, r1;


### PR DESCRIPTION
> ```
> [..]/plugins/actor/G-Force/Common/GeneralTools/UtilStr.cpp:137:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
>         register unsigned long i = 0;
>         ^~~~~~~~~
> ```