### PR TITLE
[0.4.x] libvisual: configure.ac: Define macro VISUAL_ARCH_X86_64 on x86_64

### DIFF
--- a/libvisual/configure.ac
+++ b/libvisual/configure.ac
@@ -781,6 +781,7 @@ echo >>$outfile
    lv_alpha=$lv_alpha
    lv_sparc=$lv_sparc
    lv_ix86=$lv_ix86
+   lv_x86_64=$lv_x86_64
    lv_powerpc=$lv_powerpc
    lv_arch_unknown=$lv_arch_unknown
 


### PR DESCRIPTION
Effect:
```console
# diff -U0 build_amd64_before/libvisual/lvconfig.h build_amd64_after/libvisual/lvconfig.h 
--- build_amd64_before/libvisual/lvconfig.h     2022-11-30 11:51:10.117382442 +0100
+++ build_amd64_after/libvisual/lvconfig.h      2022-11-30 11:52:21.197916872 +0100
@@ -28,0 +29,2 @@
+#define VISUAL_ARCH_X86_64
+
```
From https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/libvisual/files/libvisual-0.4.0-detect_amd64.patch