### PR TITLE
[0.4.x] libvisual-plugins: Fix ambiguous call compile error with Clang 15

### DIFF
--- a/libvisual-plugins/plugins/actor/G-Force/Common/UI/LineXX.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/UI/LineXX.cpp
@@ -74,13 +74,13 @@
 
 		
 	#if CLR_INTERP && P_SZ != 1
-	long len = sqrt( dx * dx + dy * dy ) + 1;
+	long len = sqrt( static_cast<float>(dx * dx + dy * dy) ) + 1;
 	dR /= len;
 	dG /= len;
 	dB /= len;
 	color = __Clr( R, G, B );
 	#elif CLR_INTERP && P_SZ == 1
-	long len = sqrt( dx * dx + dy * dy ) + 1;
+	long len = sqrt( static_cast<float>(dx * dx + dy * dy) ) + 1;
 	dR /= len;
 	color = __Clr( R, G, B );
 	#endif
@@ -154,7 +154,7 @@
 		
 			for ( j = 0; j < tw; j++ ) {
 				long tmp = j - halfW;
-				c_x = halfW - ( ( long ) sqrt( halfW * halfW - tmp * tmp ) );
+				c_x = halfW - ( ( long ) sqrt( static_cast<float>(halfW * halfW - tmp * tmp) ) );
 				center = basePtr + (j-halfW) * mBytesPerRow;
 				for ( int k = c_x; k < tw - c_x; k++ ){
 					((PIXTYPE*) center)[k-halfW] = color;


### PR DESCRIPTION
> ```
> In file included from ../../../../../../libvisual-plugins/plugins/actor/G-Force/Common/UI/PixPort.cpp:881:
> In file included from ../../../../../../libvisual-plugins/plugins/actor/G-Force/Common/UI/DrawXX.cpp:78:
> ../../../../../../libvisual-plugins/plugins/actor/G-Force/Common/UI/LineXX.cpp:77:13: error: call to 'sqrt' is ambiguous
>         long len = sqrt( dx * dx + dy * dy ) + 1;
>                    ^~~~
> /usr/include/x86_64-linux-gnu/bits/mathcalls.h:143:13: note: candidate function
> __MATHCALL (sqrt,, (_Mdouble_ __x));
>             ^
> /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/cmath:463:3: note: candidate function
>   sqrt(float __x)
>   ^
> /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/cmath:467:3: note: candidate function
>   sqrt(long double __x)
>   ^
> ```

Alternative to half of https://gitweb.gentoo.org/repo/gentoo.git/tree/media-plugins/libvisual-plugins/files/libvisual-plugins-0.4.0-clang.patch