### PR TITLE
[0.4.x] libvisual-plugins: Fix G-Force compile on FreeBSD

### DIFF
--- a/libvisual-plugins/plugins/actor/G-Force/Common/math/Expression.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/math/Expression.cpp
@@ -4,6 +4,8 @@
 #include <gettext.h>
 #include <stdlib.h>
 
+#include <stdint.h>
+
 #include "Expression.h"
 
 #include "ExpressionDict.h"


### PR DESCRIPTION
From https://bugs.gentoo.org/179629