### PR TITLE
[0.4.x] libvisual-plugins: configure.ac: Fix automagic

### DIFF
--- a/libvisual-plugins/configure.ac
+++ b/libvisual-plugins/configure.ac
@@ -90,7 +90,18 @@ AC_SUBST([DYNAMIC_LOADER_LIBS])
 
 dnl Libraries
 
+dnl List of plugins to build
+build_input_plugins=""
+build_actor_plugins=""
+build_morph_plugins=""
+
 dnl EsounD
+AC_ARG_ENABLE([esd], AS_HELP_STRING([--disable-esd],
+	[Do not build esound input plugin @<:@default=enabled@:>@]),
+	[ENABLE_INPUT_ESD=$enableval],
+	[ENABLE_INPUT_ESD=yes])
+
+if test "$ENABLE_INPUT_ESD" = "yes"; then
 PKG_CHECK_MODULES([LIBESD], [esound >= esound_required_version],
   [HAVE_ESD="yes"], [HAVE_ESD="no"])
 
@@ -99,8 +110,15 @@ if test "$HAVE_ESD" = "yes"; then
 else
   AC_MSG_WARN([*** EsounD not found or too old. The EsounD input plugin won't be built])
 fi
+fi
 
 dnl JACK
+AC_ARG_ENABLE([jack], AS_HELP_STRING([--disable-jack],
+	[Do not build jack input plugin @<:@default=enabled@:>@]),
+        [ENABLE_INPUT_JACK=$enableval],
+	[ENABLE_INPUT_JACK=yes])
+
+if test "$ENABLE_INPUT_JACK" = "yes"; then
 PKG_CHECK_MODULES([LIBJACK], [jack >= jack_required_version], [HAVE_JACK="yes"], [HAVE_JACK="no"])
 if test "$HAVE_JACK" = "yes"; then
   build_input_plugins="$build_input_plugins jack"
@@ -108,11 +126,7 @@ else
   AC_MSG_WARN([*** libjack is too old. You can download a newer version at
              http://jackit.sf.net/. The jackit input plugin won't be built])
 fi
-
-dnl List of plugins to build
-build_input_plugins=""
-build_actor_plugins=""
-build_morph_plugins=""
+fi
 
 dnl GdkPixbuf
 AC_ARG_ENABLE([gdkpixbuf-plugin],


### PR DESCRIPTION
This is patch `050_all_automagic.patch` from [`libvisual-plugins-0.4.0-patches-4.tar.bz2`](http://ftp.spline.inf.fu-berlin.de/mirrors/gentoo/distfiles/23/libvisual-plugins-0.4.0-patches-4.tar.bz2) of Gentoo Linux.
Related: https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies