### PR TITLE
[0.4.x] libvisual-plugins: Fix buffer overflow (method fusee, file draw.c) in jess

### DIFF
--- a/libvisual-plugins/plugins/actor/JESS/draw.c
+++ b/libvisual-plugins/plugins/actor/JESS/draw.c
@@ -69,7 +69,7 @@ void fusee(JessPrivate *priv, uint8_t * buffer, int new)
 		while (priv->life[i] > 0)
 		{
 			i++;
-			if (i == FUSEE_MAX+1)
+			if (i == FUSEE_MAX)
 				return;
 		}
 		priv->xi[i] = visual_random_context_int(priv->rcontext) % priv->resx - priv->xres2;


### PR DESCRIPTION
This is from https://github.com/Pardus-Linux/Packages/blob/master/multimedia/plugin/libvisual-plugins/files/libvisual-plugins-buffer-overflow.patch

The related declarations are:
> ```
> plugins/actor/JESS/jess.h:78:   int xi[FUSEE_MAX];
> plugins/actor/JESS/jess.h:80:   float life[FUSEE_MAX];
> ```