### PR TITLE
[0.4.x] libvisual: Fix conversion of color to uint32

### DIFF
--- a/libvisual/libvisual/lv_color.c
+++ b/libvisual/libvisual/lv_color.c
@@ -260,7 +260,7 @@ uint32_t visual_color_to_uint32 (VisColor *color)
 
 	visual_log_return_val_if_fail (color != NULL, 0);
 
-	colors = (256 << 24) |
+	colors = (0xFF << 24) |
 		(color->r << 16) |
 		(color->g << 8) |
 		(color->b);


### PR DESCRIPTION
Original report: https://sourceforge.net/p/libvisual/bugs/18/

```c
#include <stdint.h>
#include <stdio.h>

int main() {
        int r = 0x11;
        int g = 0x22;
        int b = 0x33;

        uint32_t colors;

        colors = (256 << 24) | (r << 16) | (g << 8) | b;
        printf("Old: 0x%08x\n", colors);

        colors = (255 << 24) | (r << 16) | (g << 8) | b;
        printf("New: 0x%08x\n", colors);

        return 0;
}
```

```console
# gcc main.c && ./a.out
main.c: In function ‘main’:
main.c:11:23: warning: result of ‘256 << 24’ requires 34 bits to represent, but ‘int’ only has 32 bits [-Wshift-overflow=]
   11 |         colors = (256 << 24) | (r << 16) | (g << 8) | b;
      |                       ^~
Old: 0x00112233
New: 0xff112233
```

CC @dcb314