### PR TITLE
[0.4.x] libvisual-plugins: Fix ALSA input plugin

### DIFF
--- a/libvisual-plugins/plugins/input/alsa/input_alsa.c
+++ b/libvisual-plugins/plugins/input/alsa/input_alsa.c
@@ -51,7 +51,7 @@ static int inp_alsa_cleanup (VisPluginData *plugin);
 static int inp_alsa_upload (VisPluginData *plugin, VisAudio *audio);
 
 static const int  inp_alsa_var_btmul      = sizeof (short);
-static const char *inp_alsa_var_cdevice   = "hw:0,0";
+static const char *inp_alsa_var_cdevice   = "default";
 static const int  inp_alsa_var_samplerate = 44100;
 static const int  inp_alsa_var_channels   = 2;
 

--- a/libvisual-plugins/plugins/input/alsa/input_alsa.c
+++ b/libvisual-plugins/plugins/input/alsa/input_alsa.c
@@ -253,7 +253,7 @@ int inp_alsa_upload (VisPluginData *plugin, VisAudio *audio)
 		if (rcnt > 0) {
 			VisBuffer buffer;
 
-			visual_buffer_init (&buffer, data, rcnt, NULL);
+			visual_buffer_init (&buffer, data, rcnt * sizeof(data[0]) * inp_alsa_var_channels, NULL);
 
 			visual_audio_samplepool_input (audio->samplepool, &buffer, VISUAL_AUDIO_SAMPLE_RATE_44100,
 					VISUAL_AUDIO_SAMPLE_FORMAT_S16, VISUAL_AUDIO_SAMPLE_CHANNEL_STEREO);

--- a/libvisual-plugins/plugins/input/alsa/input_alsa.c
+++ b/libvisual-plugins/plugins/input/alsa/input_alsa.c
@@ -221,7 +221,8 @@ int inp_alsa_upload (VisPluginData *plugin, VisAudio *audio)
 {
 	int16_t data[PCM_BUF_SIZE];
 	alsaPrivate *priv = NULL;
-	int rcnt;
+	const snd_pcm_uframes_t frames_wanted = sizeof(data) / sizeof(data[0]) / inp_alsa_var_channels;
+	snd_pcm_sframes_t rcnt;
 	int i;
 
 	visual_log_return_val_if_fail(audio != NULL, -1);
@@ -247,7 +248,7 @@ int inp_alsa_upload (VisPluginData *plugin, VisAudio *audio)
 	}
 #endif
 	do {
-		rcnt = snd_pcm_readi(priv->chandle, data, PCM_BUF_SIZE / 2);
+		rcnt = snd_pcm_readi(priv->chandle, data, frames_wanted);
 
 		if (rcnt > 0) {
 			VisBuffer buffer;

--- a/libvisual-plugins/plugins/input/alsa/input_alsa.c
+++ b/libvisual-plugins/plugins/input/alsa/input_alsa.c
@@ -106,7 +106,7 @@ int inp_alsa_init (VisPluginData *plugin)
 
 	visual_object_set_private (VISUAL_OBJECT (plugin), priv);
 
-	if ((err = snd_pcm_open(&priv->chandle, strdup(inp_alsa_var_cdevice),
+	if ((err = snd_pcm_open(&priv->chandle, inp_alsa_var_cdevice,
 			SND_PCM_STREAM_CAPTURE, SND_PCM_NONBLOCK)) < 0) {
 		visual_log(VISUAL_LOG_CRITICAL, 
 			    _("Record open error: %s"), snd_strerror(err));

--- a/libvisual-plugins/plugins/input/alsa/input_alsa.c
+++ b/libvisual-plugins/plugins/input/alsa/input_alsa.c
@@ -229,6 +229,10 @@ int inp_alsa_upload (VisPluginData *plugin, VisAudio *audio)
 	priv = visual_object_get_private (VISUAL_OBJECT (plugin));
 	visual_log_return_val_if_fail(priv != NULL, -1);
 
+	if (priv->chandle == NULL) {
+		return -1;
+	}
+
 #if 0
 	{	/* DEBUG STUFF, REMOVE IN RELEASE FIXME FIXME XXX TODO WHATEVER */
 		VisBuffer buffer;

--- a/libvisual-plugins/plugins/input/alsa/input_alsa.c
+++ b/libvisual-plugins/plugins/input/alsa/input_alsa.c
@@ -24,6 +24,7 @@
 
 #include <config.h>
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -53,6 +54,7 @@ static int inp_alsa_upload (VisPluginData *plugin, VisAudio *audio);
 static const int  inp_alsa_var_btmul      = sizeof (short);
 static const char *inp_alsa_var_cdevice   = "default";
 static const int  inp_alsa_var_samplerate = 44100;
+static const int  inp_alsa_var_frames_target = 256;
 static const int  inp_alsa_var_channels   = 2;
 
 VISUAL_PLUGIN_API_VERSION_VALIDATOR
@@ -165,16 +167,14 @@ int inp_alsa_init (VisPluginData *plugin)
 		return(-1);
 	}
 
-       /* Setup a large buffer */
-
-	tmp = 1000000;
+	tmp = (int)ceil((1000.0 * 1000.0 * inp_alsa_var_frames_target) / inp_alsa_var_samplerate);  // in micro seconds
 	if (snd_pcm_hw_params_set_period_time_near(priv->chandle, hwparams, &tmp, &dir) < 0){
 		visual_log(VISUAL_LOG_CRITICAL, _("Error setting period time"));
 		snd_pcm_hw_params_free(hwparams);
 		return(-1);
 	}
 
-	tmp = 1000000*4;
+	tmp = (int)ceil((1000.0 * 1000.0 * inp_alsa_var_frames_target) / inp_alsa_var_samplerate);  // in micro seconds
 	if (snd_pcm_hw_params_set_buffer_time_near(priv->chandle, hwparams, &tmp, &dir) < 0){
 		visual_log(VISUAL_LOG_CRITICAL, _("Error setting buffer time"));
 		snd_pcm_hw_params_free(hwparams);

--- a/libvisual-plugins/po/de.po
+++ b/libvisual-plugins/po/de.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libvisual-plugins 0.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-13 23:31+0100\n"
+"POT-Creation-Date: 2023-01-14 20:48+0100\n"
 "PO-Revision-Date: 2017-11-23 18:08:07+0200\n"
 "Last-Translator: Chris Leick <c.leick@vollbio.de>\n"
 "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
@@ -364,38 +364,38 @@ msgstr "gelbe Rose von Texas-Portierung von Libvisual"
 msgid "This renders an awesome responsive flower"
 msgstr "Dies berechnet eine tolle ansprechende Blume"
 
-#: plugins/input/alsa/input_alsa.c:73
+#: plugins/input/alsa/input_alsa.c:75
 msgid "ALSA capture plugin"
 msgstr "ALSA-Erfassungserweiterung"
 
-#: plugins/input/alsa/input_alsa.c:74
+#: plugins/input/alsa/input_alsa.c:76
 msgid "Use this plugin to capture PCM data from the ALSA record device"
 msgstr ""
 "Benutzen Sie diese Erweiterung, um PCM-Daten vom ALSA-Aufzeichungsgerät zu "
 "erfassen."
 
-#: plugins/input/alsa/input_alsa.c:112
+#: plugins/input/alsa/input_alsa.c:114
 #, c-format
 msgid "Record open error: %s"
 msgstr "Fehler beim Öffnen des Datensatzes: %s"
 
-#: plugins/input/alsa/input_alsa.c:121
+#: plugins/input/alsa/input_alsa.c:123
 msgid "Cannot configure this PCM device"
 msgstr "Dieses PCM-Gerät kann nicht konfiguriert werden."
 
-#: plugins/input/alsa/input_alsa.c:128
+#: plugins/input/alsa/input_alsa.c:130
 msgid "Error setting access"
 msgstr "Fehler beim Setzen des Zugriffs"
 
-#: plugins/input/alsa/input_alsa.c:140
+#: plugins/input/alsa/input_alsa.c:142
 msgid "Error setting format"
 msgstr "Fehler beim Setzen des Formats"
 
-#: plugins/input/alsa/input_alsa.c:149
+#: plugins/input/alsa/input_alsa.c:151
 msgid "Error setting rate"
 msgstr "Fehler beim Setzen der Frequenz"
 
-#: plugins/input/alsa/input_alsa.c:155
+#: plugins/input/alsa/input_alsa.c:157
 #, c-format
 msgid ""
 "The rate %d Hz is not supported by your hardware.\n"
@@ -404,7 +404,7 @@ msgstr ""
 "Die Frequenz %d Hz wird nicht von Ihrer Hardware unterstützt.\n"
 "==> Stattdessen wird %d Hz benutzt"
 
-#: plugins/input/alsa/input_alsa.c:163
+#: plugins/input/alsa/input_alsa.c:165
 msgid "Error setting channels"
 msgstr "Fehler beim Setzen des Kanals"
 
@@ -420,11 +420,11 @@ msgstr "Fehler beim Setzen der Pufferzeit"
 msgid "Error setting HW params"
 msgstr "Fehler beim Setzen der Hardwareparameter"
 
-#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:263
+#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:268
 msgid "Failed to prepare interface"
 msgstr "Vorbereiten der Schnittstelle fehlgeschlagen"
 
-#: plugins/input/alsa/input_alsa.c:259
+#: plugins/input/alsa/input_alsa.c:264
 msgid "ALSA: Buffer Overrun"
 msgstr "ALSA: Pufferüberlauf"
 

--- a/libvisual-plugins/po/es_AR.po
+++ b/libvisual-plugins/po/es_AR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Libvisual plugins 0.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-13 23:31+0100\n"
+"POT-Creation-Date: 2023-01-14 20:48+0100\n"
 "PO-Revision-Date: 2005-03-16 00:11-0300\n"
 "Last-Translator: Duilio Javier Protti <dprotti@users.sourceforge.net>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -351,38 +351,38 @@ msgstr ""
 msgid "This renders an awesome responsive flower"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:73
+#: plugins/input/alsa/input_alsa.c:75
 msgid "ALSA capture plugin"
 msgstr "Plugin de captura de audio ALSA"
 
-#: plugins/input/alsa/input_alsa.c:74
+#: plugins/input/alsa/input_alsa.c:76
 msgid "Use this plugin to capture PCM data from the ALSA record device"
 msgstr ""
 "Use este plugin para capturar datos PCM del dispositivo de grabación ALSA"
 
-#: plugins/input/alsa/input_alsa.c:112
+#: plugins/input/alsa/input_alsa.c:114
 #, c-format
 msgid "Record open error: %s"
 msgstr "Error al iniciar grabación: %s"
 
-#: plugins/input/alsa/input_alsa.c:121
+#: plugins/input/alsa/input_alsa.c:123
 #, fuzzy
 msgid "Cannot configure this PCM device"
 msgstr "No se puede configurar este dispositivo PCM"
 
-#: plugins/input/alsa/input_alsa.c:128
+#: plugins/input/alsa/input_alsa.c:130
 msgid "Error setting access"
 msgstr "Error al configurar el acceso"
 
-#: plugins/input/alsa/input_alsa.c:140
+#: plugins/input/alsa/input_alsa.c:142
 msgid "Error setting format"
 msgstr "Error al configurar el formato"
 
-#: plugins/input/alsa/input_alsa.c:149
+#: plugins/input/alsa/input_alsa.c:151
 msgid "Error setting rate"
 msgstr "Error al configurar la tasa"
 
-#: plugins/input/alsa/input_alsa.c:155
+#: plugins/input/alsa/input_alsa.c:157
 #, c-format
 msgid ""
 "The rate %d Hz is not supported by your hardware.\n"
@@ -391,7 +391,7 @@ msgstr ""
 "Una tasa de %d Hz no es soportada por su hardware.\n"
 "==> Se usarán %d Hz"
 
-#: plugins/input/alsa/input_alsa.c:163
+#: plugins/input/alsa/input_alsa.c:165
 msgid "Error setting channels"
 msgstr "Error al configurar los canales"
 
@@ -407,11 +407,11 @@ msgstr "Error al configurar el tiempo de buffer"
 msgid "Error setting HW params"
 msgstr "Error al configurar parámetros de hardware"
 
-#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:263
+#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:268
 msgid "Failed to prepare interface"
 msgstr "Fallo al preparar la interfaz"
 
-#: plugins/input/alsa/input_alsa.c:259
+#: plugins/input/alsa/input_alsa.c:264
 #, fuzzy
 msgid "ALSA: Buffer Overrun"
 msgstr "Buffer Overrun"

--- a/libvisual-plugins/po/es_ES.po
+++ b/libvisual-plugins/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Libvisual plugins 0.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-13 23:31+0100\n"
+"POT-Creation-Date: 2023-01-14 20:48+0100\n"
 "PO-Revision-Date: 2005-03-16 00:11-0300\n"
 "Last-Translator: Duilio Javier Protti <dprotti@users.sourceforge.net>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -351,38 +351,38 @@ msgstr ""
 msgid "This renders an awesome responsive flower"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:73
+#: plugins/input/alsa/input_alsa.c:75
 msgid "ALSA capture plugin"
 msgstr "Plugin de captura de audio ALSA"
 
-#: plugins/input/alsa/input_alsa.c:74
+#: plugins/input/alsa/input_alsa.c:76
 msgid "Use this plugin to capture PCM data from the ALSA record device"
 msgstr ""
 "Use este plugin para capturar datos PCM del dispositivo de grabación ALSA"
 
-#: plugins/input/alsa/input_alsa.c:112
+#: plugins/input/alsa/input_alsa.c:114
 #, c-format
 msgid "Record open error: %s"
 msgstr "Error al iniciar grabación: %s"
 
-#: plugins/input/alsa/input_alsa.c:121
+#: plugins/input/alsa/input_alsa.c:123
 #, fuzzy
 msgid "Cannot configure this PCM device"
 msgstr "No se puede configurar este dispositivo PCM"
 
-#: plugins/input/alsa/input_alsa.c:128
+#: plugins/input/alsa/input_alsa.c:130
 msgid "Error setting access"
 msgstr "Error al configurar el acceso"
 
-#: plugins/input/alsa/input_alsa.c:140
+#: plugins/input/alsa/input_alsa.c:142
 msgid "Error setting format"
 msgstr "Error al configurar el formato"
 
-#: plugins/input/alsa/input_alsa.c:149
+#: plugins/input/alsa/input_alsa.c:151
 msgid "Error setting rate"
 msgstr "Error al configurar la tasa"
 
-#: plugins/input/alsa/input_alsa.c:155
+#: plugins/input/alsa/input_alsa.c:157
 #, c-format
 msgid ""
 "The rate %d Hz is not supported by your hardware.\n"
@@ -391,7 +391,7 @@ msgstr ""
 "Una tasa de %d Hz no es soportada por su hardware.\n"
 "==> Se usarán %d Hz"
 
-#: plugins/input/alsa/input_alsa.c:163
+#: plugins/input/alsa/input_alsa.c:165
 msgid "Error setting channels"
 msgstr "Error al configurar los canales"
 
@@ -407,11 +407,11 @@ msgstr "Error al configurar el tiempo de buffer"
 msgid "Error setting HW params"
 msgstr "Error al configurar parámetros de hardware"
 
-#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:263
+#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:268
 msgid "Failed to prepare interface"
 msgstr "Fallo al preparar la interfaz"
 
-#: plugins/input/alsa/input_alsa.c:259
+#: plugins/input/alsa/input_alsa.c:264
 #, fuzzy
 msgid "ALSA: Buffer Overrun"
 msgstr "Buffer Overrun"

--- a/libvisual-plugins/po/libvisual-plugins-0.4.pot
+++ b/libvisual-plugins/po/libvisual-plugins-0.4.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libvisual-plugins 0.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-13 23:31+0100\n"
+"POT-Creation-Date: 2023-01-14 20:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -334,43 +334,43 @@ msgstr ""
 msgid "This renders an awesome responsive flower"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:73
+#: plugins/input/alsa/input_alsa.c:75
 msgid "ALSA capture plugin"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:74
+#: plugins/input/alsa/input_alsa.c:76
 msgid "Use this plugin to capture PCM data from the ALSA record device"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:112
+#: plugins/input/alsa/input_alsa.c:114
 #, c-format
 msgid "Record open error: %s"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:121
+#: plugins/input/alsa/input_alsa.c:123
 msgid "Cannot configure this PCM device"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:128
+#: plugins/input/alsa/input_alsa.c:130
 msgid "Error setting access"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:140
+#: plugins/input/alsa/input_alsa.c:142
 msgid "Error setting format"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:149
+#: plugins/input/alsa/input_alsa.c:151
 msgid "Error setting rate"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:155
+#: plugins/input/alsa/input_alsa.c:157
 #, c-format
 msgid ""
 "The rate %d Hz is not supported by your hardware.\n"
 "==> Using %d Hz instead"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:163
+#: plugins/input/alsa/input_alsa.c:165
 msgid "Error setting channels"
 msgstr ""
 
@@ -386,11 +386,11 @@ msgstr ""
 msgid "Error setting HW params"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:263
+#: plugins/input/alsa/input_alsa.c:192 plugins/input/alsa/input_alsa.c:268
 msgid "Failed to prepare interface"
 msgstr ""
 
-#: plugins/input/alsa/input_alsa.c:259
+#: plugins/input/alsa/input_alsa.c:264
 msgid "ALSA: Buffer Overrun"
 msgstr ""
 


### PR DESCRIPTION
Should ideally be merged *after* pull request #152 or it will further increase the buffer overflow problem that #152 is fixing.