### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pacman -S --needed --ask=20 --noconfirm `
+          pacman -Sy --needed --ask=20 --noconfirm `
             mingw-w64-x86_64-dlfcn `
             mingw-w64-x86_64-orc `
             mingw-w64-x86_64-pkgconf `


### PR DESCRIPTION
Error was:
> warning: database file for 'clangarm64' does not exist (use '-Sy' to download)
> error: failed to prepare transaction (could not find database)

https://github.com/Libvisual/libvisual/actions/runs/3852262686/jobs/6578593104