### PR TITLE
[0.4.x] libvisual-plugins: Free timer during cleanup for actor "lv_gltest"

### DIFF
--- a/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
+++ b/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
@@ -190,6 +190,10 @@ int lv_gltest_cleanup (VisPluginData *plugin)
 	ui = visual_plugin_get_userinterface (plugin);
 	visual_object_unref (VISUAL_OBJECT (ui));
 
+	if (priv) {
+	    visual_object_unref (VISUAL_OBJECT (priv->started_at));
+	}
+
 	visual_mem_free (priv);
 
 	return 0;


### PR DESCRIPTION
Related:
- Pull request #153 
- Comment https://github.com/Libvisual/libvisual/pull/163#issuecomment-1382580104