### PR TITLE
Minor C++ code improvements

### DIFF
--- a/libvisual/libvisual/lv_fourier.cpp
+++ b/libvisual/libvisual/lv_fourier.cpp
@@ -108,8 +108,7 @@ namespace LV {
         if (entry != m_cache.end ())
             return entry->second;
 
-        // FIXME: Use emplace() when libstdc++ supports it
-        m_cache[sample_count] = Entry (method, sample_count);
+        m_cache.emplace (sample_count, Entry {method, sample_count});
 
         return m_cache[sample_count];
     }

--- a/libvisual/libvisual/lv_param.cpp
+++ b/libvisual/libvisual/lv_param.cpp
@@ -185,7 +185,7 @@ namespace LV
 
       param->parent = this;
 
-      m_impl->entries.emplace(param->name, std::unique_ptr<Param> {param});
+      m_impl->entries.emplace (param->name, std::unique_ptr<Param> {param});
   }
 
   bool ParamList::remove (std::string const& name)

--- a/libvisual/libvisual/lv_param.cpp
+++ b/libvisual/libvisual/lv_param.cpp
@@ -52,7 +52,7 @@ namespace LV
   {
   public:
 
-      typedef std::list<std::unique_ptr<Closure> > HandlerList;
+      typedef std::list<std::unique_ptr<Closure>> HandlerList;
 
       ParamList*     parent;
       std::string    name;

--- a/libvisual/libvisual/lv_param.cpp
+++ b/libvisual/libvisual/lv_param.cpp
@@ -24,6 +24,7 @@
 #include "lv_common.h"
 #include "lv_util.hpp"
 #include <map>
+#include <memory>
 #include <list>
 #include <stdexcept>
 #include <cstdarg>
@@ -184,8 +185,7 @@ namespace LV
 
       param->parent = this;
 
-      // libstdc++ 4.6/4.7 still does not have std::map<T>::emplace()
-      m_impl->entries[param->name] = std::unique_ptr<Param> {param};
+      m_impl->entries.emplace(param->name, std::unique_ptr<Param> {param});
   }
 
   bool ParamList::remove (std::string const& name)


### PR DESCRIPTION
* Use `emplace()` instead of `insert()` or `operator[]`, where possible. Availability is guaranteed now after 10 years for the standard map containers!
* Remove spaces between closing brackets of nested templates.
