### PR TITLE
libvisual-plugins: Fix memory leak in lcdcontrol.

### DIFF
--- a/libvisual-plugins/plugins/actor/lcdcontrol/LCDGraphic.cpp
+++ b/libvisual-plugins/plugins/actor/lcdcontrol/LCDGraphic.cpp
@@ -155,7 +155,7 @@ LCDGraphic::~LCDGraphic() {
     free(LayoutFB);
     free(TransitionFB);
     free(VideoFB);
-    visual_video_free_buffer(video_);
+    visual_video_unref(video_);
 }
 
 

--- a/libvisual-plugins/plugins/actor/lcdcontrol/WidgetVisualization.cpp
+++ b/libvisual-plugins/plugins/actor/lcdcontrol/WidgetVisualization.cpp
@@ -253,7 +253,7 @@ void WidgetVisualization::DoParams() {
 
 WidgetVisualization::~WidgetVisualization() {
     delete []peak_buffer_;
-    visual_video_free_buffer(video_);
+    visual_video_unref(video_);
 }
 
 void  WidgetVisualization::Resize(int rows, int cols, int old_rows, int old_cols) {
@@ -266,7 +266,7 @@ void  WidgetVisualization::Resize(int rows, int cols, int old_rows, int old_cols
     row_ = round(rows * r);
     col_ = round(cols * c);
 
-    visual_video_free_buffer(video_);
+    visual_video_unref(video_);
 
     // Set depth
     int depthflag = visual_actor_get_supported_depths(actor_);
@@ -408,7 +408,7 @@ void WidgetVisualization::UpdatePCM()
 
         depth_ = visual_video_depth_get_highest_nogl(depthflag);
 
-        visual_video_free_buffer(video_);
+        visual_video_unref(video_);
 
         video_ = visual_video_new_with_buffer(cols_, rows_, depth_);
 


### PR DESCRIPTION
While stripping down the `VisVideo` API surface, I noticed that `lcdcontrol` uses `visual_video_free_buffer()` to free `VisVideo` instances. This will leak because the `VisVideo` object itself is not freed by this function. Replaced with `visual_video_unref()`.

This makes my argument that the `VisVideo` parameters should be immutable once the instance is constructed. Only its buffer contents may be changed.