### PR TITLE
libvisual: Remove VisVideo C API for altering parameters after creation

### DIFF
--- a/libvisual/libvisual/lv_video.h
+++ b/libvisual/libvisual/lv_video.h
@@ -496,11 +496,7 @@ LV_API VisVideo *visual_video_load_from_file  (const char *path);
 LV_API void visual_video_ref   (VisVideo *video);
 LV_API void visual_video_unref (VisVideo *video);
 
-LV_API int  visual_video_allocate_buffer (VisVideo *video);
-LV_API void visual_video_free_buffer (VisVideo *video);
 LV_API int  visual_video_has_allocated_buffer (VisVideo *video);
-
-LV_API void visual_video_copy_attrs (VisVideo *dest, VisVideo *src);
 
 LV_API int visual_video_compare_attrs (VisVideo *src1, VisVideo *src2);
 LV_API int visual_video_compare_attrs_ignore_pitch (VisVideo *src1, VisVideo *src2);
@@ -508,15 +504,11 @@ LV_API int visual_video_compare_attrs_ignore_pitch (VisVideo *src1, VisVideo *sr
 LV_API void        visual_video_set_palette (VisVideo *video, VisPalette *pal);
 LV_API VisPalette* visual_video_get_palette (VisVideo *video);
 
-LV_API void visual_video_set_attrs (VisVideo *video, int width, int height, int pitch, VisVideoDepth depth);
-
 LV_API int visual_video_get_width  (VisVideo *video);
 LV_API int visual_video_get_height (VisVideo *video);
 
-LV_API void visual_video_set_pitch (VisVideo *video, int pitch);
 LV_API int  visual_video_get_pitch (VisVideo *video);
 
-LV_API void          visual_video_set_depth (VisVideo *video, VisVideoDepth depth);
 LV_API VisVideoDepth visual_video_get_depth (VisVideo *video);
 
 LV_API int visual_video_get_bpp (VisVideo *video);

--- a/libvisual/libvisual/lv_video_c.cpp
+++ b/libvisual/libvisual/lv_video_c.cpp
@@ -68,33 +68,11 @@ VisVideo *visual_video_load_from_file (const char *path)
     return self.get ();
 }
 
-void visual_video_free_buffer (VisVideo *self)
-{
-    visual_return_if_fail (self != nullptr);
-
-    self->free_buffer ();
-}
-
-int visual_video_allocate_buffer (VisVideo *self)
-{
-    visual_return_val_if_fail (self != nullptr, FALSE);
-
-    return self->allocate_buffer ();
-}
-
 int visual_video_has_allocated_buffer (VisVideo *self)
 {
     visual_return_val_if_fail (self != nullptr, FALSE);
 
     return self->has_allocated_buffer ();
-}
-
-void visual_video_copy_attrs (VisVideo *self, VisVideo *src)
-{
-    visual_return_if_fail (self != nullptr);
-    visual_return_if_fail (src  != nullptr);
-
-    self->copy_attrs (LV::VideoPtr (src));
 }
 
 int visual_video_compare_attrs (VisVideo *self, VisVideo *src)
@@ -150,25 +128,11 @@ int visual_video_get_height (VisVideo *self)
     return self->get_height ();
 }
 
-void visual_video_set_pitch (VisVideo *self, int pitch)
-{
-    visual_return_if_fail (self != nullptr);
-
-    self->set_pitch (pitch);
-}
-
 int visual_video_get_pitch (VisVideo *self)
 {
     visual_return_val_if_fail (self != nullptr, 0);
 
     return self->get_pitch ();
-}
-
-void visual_video_set_depth (VisVideo *self, VisVideoDepth depth)
-{
-    visual_return_if_fail (self != nullptr);
-
-    self->set_depth (depth);
 }
 
 VisVideoDepth visual_video_get_depth (VisVideo *self)
@@ -183,13 +147,6 @@ int visual_video_get_bpp (VisVideo *self)
     visual_return_val_if_fail (self != nullptr, 0);
 
     return self->get_bpp ();
-}
-
-void visual_video_set_attrs (VisVideo *self, int width, int height, int pitch, VisVideoDepth depth)
-{
-    visual_return_if_fail (self != nullptr);
-
-    self->set_attrs (width, height, pitch, depth);
 }
 
 visual_size_t visual_video_get_size (VisVideo *self)


### PR DESCRIPTION
Part of the ongoing API streamlining and reworking.

Two points I want to make:
- The C++ methods are retained at the moment as they are used internally by `LV::Bin`, `LV::Actor`, and `LV::Morph`. They will be removed too in time.
- I discovered more `lcdcontrol` plugin code that uses `visual_buffer_free_buffer()` to free `VisVideo` instances. They are not currently configured to build so I will leave them in for now.