### PR TITLE
[0.4.x] libvisual: Fix ringbuffer infinite loop

### DIFF
--- a/libvisual/libvisual/lv_ringbuffer.c
+++ b/libvisual/libvisual/lv_ringbuffer.c
@@ -416,8 +416,13 @@ int visual_ringbuffer_get_data_from_end (VisRingBuffer *ringbuffer, VisBuffer *d
 	int totalsize = visual_ringbuffer_get_size (ringbuffer);
 	int offset = totalsize - nbytes;
 
-	if ((nbytes / totalsize) > 0)
+	if ((totalsize != 0) && (nbytes > totalsize)) {
 		offset = totalsize - (nbytes % totalsize);
+	}
+
+	if (offset < 0) {
+	    offset = 0;
+	}
 
 	return visual_ringbuffer_get_data_offset (ringbuffer, data, offset, nbytes);
 }

--- a/libvisual/libvisual/lv_ringbuffer.c
+++ b/libvisual/libvisual/lv_ringbuffer.c
@@ -269,7 +269,7 @@ int visual_ringbuffer_get_data_offset (VisRingBuffer *ringbuffer, VisBuffer *dat
 	curposition = buffercorr;
 
 	/* Buffer fixated with partial segment, request the other segments */
-	while (curposition < nbytes) {
+	{
 		int lindex = 0;
 		le = NULL;
 
@@ -326,20 +326,16 @@ int visual_ringbuffer_get_data_offset (VisRingBuffer *ringbuffer, VisBuffer *dat
 			if (curposition == nbytes)
 				return VISUAL_OK;
 		}
-
-		if (entry == NULL) {
-		    // Silence the remaining bytes that we could not fill with
-		    // actual audio
-		    const size_t bytes_to_silence = nbytes - curposition;
-		    void * const target = visual_buffer_get_data (data) + curposition;
-		    memset(target, 0, bytes_to_silence);
-		    return -VISUAL_ERROR_IMPOSSIBLE;
-		}
-
-		startat = 0;
 	}
 
-	return VISUAL_OK;
+	assert (entry == NULL);
+
+	// Silence the remaining bytes that we could not fill with
+	// actual audio
+	const size_t bytes_to_silence = nbytes - curposition;
+	void * const target = visual_buffer_get_data (data) + curposition;
+	visual_mem_set (target, 0, bytes_to_silence);
+	return -VISUAL_ERROR_IMPOSSIBLE;
 }
 
 static int fixate_with_partial_data_request (VisRingBuffer *ringbuffer, VisBuffer *data, int offset, int nbytes,

--- a/libvisual/libvisual/lv_ringbuffer.c
+++ b/libvisual/libvisual/lv_ringbuffer.c
@@ -260,6 +260,7 @@ int visual_ringbuffer_get_data_offset (VisRingBuffer *ringbuffer, VisBuffer *dat
 
 	visual_log_return_val_if_fail (ringbuffer != NULL, -VISUAL_ERROR_RINGBUFFER_NULL);
 	visual_log_return_val_if_fail (data != NULL, -VISUAL_ERROR_BUFFER_NULL);
+	visual_log_return_val_if_fail (offset >= 0, -VISUAL_ERROR_IMPOSSIBLE);
 
 	/* Fixate possible partial buffer */
 	if (offset > 0)
@@ -324,6 +325,15 @@ int visual_ringbuffer_get_data_offset (VisRingBuffer *ringbuffer, VisBuffer *dat
 			/* Filled without room for partial buffer addition */
 			if (curposition == nbytes)
 				return VISUAL_OK;
+		}
+
+		if (entry == NULL) {
+		    // Silence the remaining bytes that we could not fill with
+		    // actual audio
+		    const size_t bytes_to_silence = nbytes - curposition;
+		    void * const target = visual_buffer_get_data (data) + curposition;
+		    memset(target, 0, bytes_to_silence);
+		    return -VISUAL_ERROR_IMPOSSIBLE;
 		}
 
 		startat = 0;


### PR DESCRIPTION
One way to see the unfixed behavior in action is to run
1. Fire up `mplayer -af export <some_media_file>`.
2. Run `lv-tool --input mplayer`.
3. Stop mplayer playback or close mplayer.
4. Wait for lv-tool to appear frozen while running in circles in `visual_ringbuffer_get_data_offset`.
