### PR TITLE
[0.4.x] lv-tool: Always skip actors "gstreamer" and "gdkpixbuf" when cycling

### DIFF
--- a/libvisual/po/de.po
+++ b/libvisual/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libvisual 0.4.0-2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-19 17:24+0100\n"
+"POT-Creation-Date: 2023-01-22 04:12+0100\n"
 "PO-Revision-Date: 2017-08-10 18:46+GMT\n"
 "Last-Translator: Chris Leick <c.leick@vollbio.de>\n"
 "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr "Ungültige Tiefe an Scaler übergeben"
 
-#: tools/lv-tool/lv-tool.cpp:748 tools/lv-tool/lv-tool.cpp:845
+#: tools/lv-tool/lv-tool.cpp:755 tools/lv-tool/lv-tool.cpp:852
 msgid "lv-tool"
 msgstr ""
 

--- a/libvisual/po/es_AR.po
+++ b/libvisual/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Libvisual Library 0.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-19 17:24+0100\n"
+"POT-Creation-Date: 2023-01-22 04:12+0100\n"
 "PO-Revision-Date: 2005-03-20 17:09-0300\n"
 "Last-Translator:  <dprotti@users.sourceforge.net>\n"
 "Language-Team: Spanish\n"
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr "Profundidad pasada al escalador inválida"
 
-#: tools/lv-tool/lv-tool.cpp:748 tools/lv-tool/lv-tool.cpp:845
+#: tools/lv-tool/lv-tool.cpp:755 tools/lv-tool/lv-tool.cpp:852
 msgid "lv-tool"
 msgstr ""
 

--- a/libvisual/po/es_ES.po
+++ b/libvisual/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Libvisual Library 0.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-19 17:24+0100\n"
+"POT-Creation-Date: 2023-01-22 04:12+0100\n"
 "PO-Revision-Date: 2005-03-20 17:09-0300\n"
 "Last-Translator:  <dprotti@users.sourceforge.net>\n"
 "Language-Team: Spanish\n"
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr "Profundidad pasada al escalador inválida"
 
-#: tools/lv-tool/lv-tool.cpp:748 tools/lv-tool/lv-tool.cpp:845
+#: tools/lv-tool/lv-tool.cpp:755 tools/lv-tool/lv-tool.cpp:852
 msgid "lv-tool"
 msgstr ""
 

--- a/libvisual/po/libvisual-0.4.pot
+++ b/libvisual/po/libvisual-0.4.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libvisual 0.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-19 17:24+0100\n"
+"POT-Creation-Date: 2023-01-22 04:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -871,6 +871,6 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr ""
 
-#: tools/lv-tool/lv-tool.cpp:748 tools/lv-tool/lv-tool.cpp:845
+#: tools/lv-tool/lv-tool.cpp:755 tools/lv-tool/lv-tool.cpp:852
 msgid "lv-tool"
 msgstr ""

--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -642,6 +642,13 @@ namespace {
           new_name = cycler (nullptr);
       }
 
+      // Always skip actors that are of little interest to end users,
+      // while allowing explicit "--actor (gdkpixbuf|gstreamer)".
+      if (strcmp (new_name, "gdkpixbuf") == 0 \
+            || strcmp (new_name, "gstreamer") == 0) {
+          return cycle_actor_name (new_name, dir);
+      }
+
       // FIXME: this won't work if an actor's name is used as part of
       // another actor's name
       if (exclude_actors.find (new_name) != std::string::npos) {


### PR DESCRIPTION
Inspired by https://github.com/hartwork/xmms2-devel/blob/2b8cc16791aceaf6ff121418041f1f6ae9f99c86/src/clients/vistest/libvisual.c#L142 .