### PR TITLE
libvisual: Fix SDL header location with regard to pkg-config, e.g. for macOS

### DIFF
--- a/libvisual/examples/simple/simple_example.hpp
+++ b/libvisual/examples/simple/simple_example.hpp
@@ -24,7 +24,7 @@
 #define _LV_EXAMPLES_SIMPLE_EXAMPLE
 
 #include <libvisual.h>
-#include <SDL/SDL.h>
+#include <SDL.h>
 
 class SimpleExample
 {

--- a/libvisual/tools/lv-tool/display/sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/sdl_driver.cpp
@@ -27,7 +27,7 @@
 #include "display_driver.hpp"
 #include <libvisual/libvisual.h>
 
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <array>
 
 namespace {

--- a/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
@@ -28,7 +28,7 @@
 #include "gettext.h"
 #include <libvisual/libvisual.h>
 
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <GL/gl.h>
 #include <GL/glext.h> // For GL_BGR in systems where it's not defined in GL/gl.h
 #include <array>


### PR DESCRIPTION
Forward-port of 0.4.x pull request #187 to `master`