### PR TITLE
[0.4.x] lv-tool: Fix check for a suitable palette

### DIFF
--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -401,7 +401,7 @@ namespace {
               visual_log_return_if_fail( m_screen_video != nullptr );
               VisPalette * const pal = m_screen_video->pal;
 
-              if (pal != nullptr && pal->ncolors <= 256) {
+              if (pal != nullptr && pal->ncolors >= 256) {
                   SDL_Color colors[256];
 
                   for (int i = 0; i < 256; i++) {


### PR DESCRIPTION
We can only copy 256 entries if we have them...