### PR TITLE
lv-tool: Fix check for a suitable palette

### DIFF
--- a/libvisual/tools/lv-tool/display/sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/sdl_driver.cpp
@@ -226,7 +226,7 @@ namespace {
           if (m_screen->format->BitsPerPixel == 8) {
               auto const& pal = m_display.get_video ()->get_palette ();
 
-              if (!pal.empty () && pal.size() <= 256) {
+              if (!pal.empty () && pal.size() >= 256) {
                   std::array<SDL_Color, 256> colors;
                   visual_mem_set (colors.data (), 0, sizeof (colors));
 

--- a/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
@@ -243,7 +243,7 @@ namespace {
           if (m_screen->format->BitsPerPixel == 8) {
               auto const& pal = m_display.get_video ()->get_palette ();
 
-              if (!pal.empty () && pal.size() <= 256) {
+              if (!pal.empty () && pal.size() >= 256) {
                   std::array<SDL_Color, 256> colors;
                   visual_mem_set (colors.data (), 0, sizeof (colors));
 


### PR DESCRIPTION
We can only copy 256 entries if we have them...

(based on 0.4.x commit d1edda999f2609537d983e6ed65b843d4a02a8d5 from pull request #213)