### PR TITLE
[0.4.x] libvisual-plugins: Fix issues with object destruction and font loading for actor "gforce"

### DIFF
--- a/libvisual-plugins/plugins/actor/G-Force/Common/GeneralTools/Headers/Hashable.h
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/GeneralTools/Headers/Hashable.h
@@ -8,6 +8,8 @@ class Hashable {
 		virtual long			Hash() const = 0;
 		
 		virtual bool			Equals( const Hashable* inComp ) const = 0;
+
+		virtual ~Hashable() {};
 };
 
 #endif

--- a/libvisual-plugins/plugins/actor/G-Force/Common/UI/PixPort.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/Common/UI/PixPort.cpp
@@ -136,7 +136,7 @@ void PixPort::Un_Init() {
 
 	// Free buffer
 	if (mBits) {
-	  delete mBits;
+	  delete []mBits;
 	  mBits = 0;
 	}
 	#endif

--- a/libvisual-plugins/plugins/actor/G-Force/Makefile.am
+++ b/libvisual-plugins/plugins/actor/G-Force/Makefile.am
@@ -20,5 +20,6 @@ actor_gforce_la_LIBADD = \
 	unix/libmfl/libmfl.la \
 	unix/libvisual/libactor_gforce.la
 
-EXTRA_DIST = deffont
+fontdir = $(LIBVISUAL_PLUGINS_DATA_DIR)
+dist_font_DATA = deffont
 

--- a/libvisual-plugins/plugins/actor/G-Force/unix/libmfl/mfl.c
+++ b/libvisual-plugins/plugins/actor/G-Force/unix/libmfl/mfl.c
@@ -51,7 +51,10 @@ mfl_font mfl_LoadRawFont(const char *fname) {
 
   /* Open font file */
   ff = fopen(fname, "rb");
-  if (ff == NULL) goto lrf_open_fault;
+  if (ff == NULL) {
+    visual_log (VISUAL_LOG_WARNING, "Unable to open font file: %s", fname);
+    goto lrf_open_fault;
+  }
 
   /* Get length of font file */
   if (fseek(ff, 0, SEEK_END) != 0) goto lrf_fault;
@@ -70,6 +73,7 @@ mfl_font mfl_LoadRawFont(const char *fname) {
  
   /* Read font data */
   if (fread(f->data, 1, l, ff) != l) {
+    visual_log (VISUAL_LOG_WARNING, "Unable to fully read font file: %s", fname);
     free(f->data);
     free(f);
     f = NULL;
@@ -84,7 +88,9 @@ mfl_font mfl_LoadRawFont(const char *fname) {
 }
 
 void mfl_DestroyFont(mfl_font f) {
-  visual_log_return_if_fail(f != NULL);
+  if (f == NULL) {
+    return;
+  }
   free(f->data);
   free(f);
 }


### PR DESCRIPTION
Found running `lv-tool --switch 10` with AddressSanitizer active.