### PR TITLE
Core (LV::IntrusivePtr): Implement swap() overload as a friend function.

### DIFF
--- a/libvisual/libvisual/lv_intrusive_ptr.hpp
+++ b/libvisual/libvisual/lv_intrusive_ptr.hpp
@@ -135,22 +135,17 @@ namespace LV
           rhs.m_ptr = tmp;
       }
 
+      //! Swaps two intrusive pointers.
+      friend void swap (LV::IntrusivePtr<T>& lhs, LV::IntrusivePtr<T>& rhs)
+      {
+          lhs.swap (rhs);
+      }
+
   private:
 
       T* m_ptr;
   };
 
 } // LV namespace
-
-namespace std {
-
-  // std::swap() overload for efficiently swapping IntrusivePtrs
-  template <class T>
-  void swap (LV::IntrusivePtr<T>& lhs, LV::IntrusivePtr<T>& rhs)
-  {
-      lhs.swap (rhs);
-  }
-
-} // std namespace
 
 #endif // _LV_INTRUSIVE_HPP


### PR DESCRIPTION
Overloading of functions in `std` namespace is considered undefined behaviour by the C++ standard.

We do the Right Thing by changing `LV::IntrusivePtr`'s `swap()` to a friend function that can be found using argument-dependent lookup.