### PR TITLE
[0.4.x] lv-tool: Resolve strcmp duplication around actors to always exclude from cycling

### DIFF
--- a/libvisual/po/de.po
+++ b/libvisual/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libvisual 0.4.0-2.2\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-22 13:50+0100\n"
+"POT-Creation-Date: 2023-01-27 01:58+0100\n"
 "PO-Revision-Date: 2017-08-10 18:46+GMT\n"
 "Last-Translator: Chris Leick <c.leick@vollbio.de>\n"
 "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr "Ungültige Tiefe an Scaler übergeben"
 
-#: tools/lv-tool/lv-tool.cpp:813 tools/lv-tool/lv-tool.cpp:910
+#: tools/lv-tool/lv-tool.cpp:819 tools/lv-tool/lv-tool.cpp:916
 msgid "lv-tool"
 msgstr ""
 

--- a/libvisual/po/es_AR.po
+++ b/libvisual/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Libvisual Library 0.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-22 13:50+0100\n"
+"POT-Creation-Date: 2023-01-27 01:58+0100\n"
 "PO-Revision-Date: 2005-03-20 17:09-0300\n"
 "Last-Translator:  <dprotti@users.sourceforge.net>\n"
 "Language-Team: Spanish\n"
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr "Profundidad pasada al escalador inválida"
 
-#: tools/lv-tool/lv-tool.cpp:813 tools/lv-tool/lv-tool.cpp:910
+#: tools/lv-tool/lv-tool.cpp:819 tools/lv-tool/lv-tool.cpp:916
 msgid "lv-tool"
 msgstr ""
 

--- a/libvisual/po/es_ES.po
+++ b/libvisual/po/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Libvisual Library 0.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-22 13:50+0100\n"
+"POT-Creation-Date: 2023-01-27 01:58+0100\n"
 "PO-Revision-Date: 2005-03-20 17:09-0300\n"
 "Last-Translator:  <dprotti@users.sourceforge.net>\n"
 "Language-Team: Spanish\n"
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr "Profundidad pasada al escalador inválida"
 
-#: tools/lv-tool/lv-tool.cpp:813 tools/lv-tool/lv-tool.cpp:910
+#: tools/lv-tool/lv-tool.cpp:819 tools/lv-tool/lv-tool.cpp:916
 msgid "lv-tool"
 msgstr ""
 

--- a/libvisual/po/libvisual-0.4.pot
+++ b/libvisual/po/libvisual-0.4.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libvisual 0.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Libvisual/libvisual/issues/\n"
-"POT-Creation-Date: 2023-01-22 13:50+0100\n"
+"POT-Creation-Date: 2023-01-27 01:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -871,6 +871,6 @@ msgstr ""
 msgid "Invalid depth passed to the scaler"
 msgstr ""
 
-#: tools/lv-tool/lv-tool.cpp:813 tools/lv-tool/lv-tool.cpp:910
+#: tools/lv-tool/lv-tool.cpp:819 tools/lv-tool/lv-tool.cpp:916
 msgid "lv-tool"
 msgstr ""

--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -30,6 +30,7 @@
 #include <SDL.h>
 #include <stdexcept>
 #include <iostream>
+#include <unordered_set>
 #include <string>
 #include <cstdio>
 #include <cstdlib>
@@ -690,6 +691,11 @@ namespace {
       std::signal (SIGTERM, handle_termination_signal);
   }
 
+  const std::unordered_set<std::string> actors_to_skip {
+      "gdkpixbuf",
+      "gstreamer"
+  };
+
   std::string cycle_actor_name (std::string const& name, CycleDir dir)
   {
       auto cycler = (dir == CycleDir::NEXT) ? visual_actor_get_next_by_name
@@ -702,8 +708,8 @@ namespace {
 
       // Always skip actors that are of little interest to end users,
       // while allowing explicit "--actor (gdkpixbuf|gstreamer)".
-      if (strcmp (new_name, "gdkpixbuf") == 0 \
-            || strcmp (new_name, "gstreamer") == 0) {
+      const bool found = actors_to_skip.find (new_name) != actors_to_skip.end ();
+      if (found) {
           return cycle_actor_name (new_name, dir);
       }
 


### PR DESCRIPTION
Follow-up to pull request #201 to prepare/precede porting to `master`

@kaixiong some choices that were intentional (but are up for discussion) are:
- I picked `set` over `vector` because it seemed to capture intent better and performance is of no concern with only 2 entries.
- I picked `set` over `unordered_set` to not require C++11.
- I picked `set.find` over `set.contains` to not require C++20.
- I chose uppercase because the data is constant in nature.
- And put it outside the function so the code is not run more times than needed.

PS: What's a good requirement for a C++ standard for 0.4.x when ideally [everyone who is on <0.4.2 today](https://repology.org/project/libvisual/badges) should be able to update? C++03, 11, 14, 17?  C++17 [seems to require](https://en.wikipedia.org/wiki/C%2B%2B17#Compiler_support) Clang 5, GCC 8 or MSVC 2017, with GCC 8.1 released [in early 2018](https://gcc.gnu.org/gcc-8/), the latest of these three I believe. So not strictly 5 years ago, if that was the goal.

What do you think?