### PR TITLE
C99 compatibility fixes to avoid implicit function declarations

### DIFF
--- a/libvisual/libvisual/lv_libvisual.c
+++ b/libvisual/libvisual/lv_libvisual.c
@@ -30,6 +30,7 @@
 #include <gettext.h>
 
 #include "lvconfig.h"
+#include "lv_cpu.h"
 #include "lv_plugin.h"
 #include "lv_actor.h"
 #include "lv_input.h"

--- a/libvisual/libvisual/lv_transform.c
+++ b/libvisual/libvisual/lv_transform.c
@@ -35,6 +35,8 @@
 #include "lv_transform.h"
 #include "lv_mem.h"
 
+int visual_transform_init (VisTransform *transform, const char *transformname);
+
 extern VisList *__lv_plugins_transform;
 
 static int transform_dtor (VisObject *object);


### PR DESCRIPTION
Strictly speaking, C99 no longer supports implicit function declarations.  Future compilers may treat them as errors (instead of issuing warnings), to avoid accidental parameter or return type mismatches.

Include "lv_cpu.h" for the visual_cpu_initialize, visual_cpu_get_sse, visual_cpu_get_3dnow functions.  Add a prototype for visual_transform_init, so that it can be called before it is defined.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
