### PR TITLE
lv-tool: Always skip actors "gstreamer" and "gdkpixbuf" when cycling

### DIFF
--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -32,6 +32,7 @@
 #include <atomic>
 #include <stdexcept>
 #include <iostream>
+#include <unordered_set>
 #include <string>
 #include <cstdio>
 #include <cstdlib>
@@ -55,6 +56,11 @@
 #endif
 
 namespace {
+
+  const std::unordered_set<std::string> actors_to_skip {
+      "gdkpixbuf",
+      "gstreamer"
+  };
 
   std::string actor_name;
   std::string input_name = DEFAULT_INPUT;
@@ -390,8 +396,7 @@ namespace {
 
       // Always skip actors that are of little interest to end users,
       // while allowing explicit "--actor (gdkpixbuf|gstreamer)".
-      if (strcmp (new_name, "gdkpixbuf") == 0 \
-            || strcmp (new_name, "gstreamer") == 0) {
+      if (actors_to_skip.contains (new_name)) {
           return cycle_actor_name (new_name, dir);
       }
 

--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -388,6 +388,13 @@ namespace {
           new_name = cycler (nullptr);
       }
 
+      // Always skip actors that are of little interest to end users,
+      // while allowing explicit "--actor (gdkpixbuf|gstreamer)".
+      if (strcmp (new_name, "gdkpixbuf") == 0 \
+            || strcmp (new_name, "gstreamer") == 0) {
+          return cycle_actor_name (new_name, dir);
+      }
+
       // FIXME: this won't work if an actor's name is used as part of
       // another actor's name
       if (exclude_actors.find (new_name) != std::string::npos) {


### PR DESCRIPTION
Forword-port of 0.4.x pull requests #201 and #219 but with `unordered_set::contains` of C++20.