### PR TITLE
[0.4.x] lv-tool: Rename binary from "lv-tool" to "lv-tool-0.4"

### DIFF
--- a/libvisual/configure.ac
+++ b/libvisual/configure.ac
@@ -409,7 +409,7 @@ if test  x$lv_tool_enabled = xyes -o x$examples = xyes ; then
     AC_SUBST([EXAMPLES], ['simplesdl morphsdl'])
   fi
   if test x$lv_tool_enabled = xyes ; then
-    AC_SUBST([TOOLS_LV_TOOL], ['lv-tool'])
+    AC_SUBST([TOOLS_LV_TOOL], ['lv-tool-0.4'])
   fi
 fi
 

--- a/libvisual/tools/lv-tool/Makefile.am
+++ b/libvisual/tools/lv-tool/Makefile.am
@@ -2,9 +2,9 @@
 
 bin_PROGRAMS = $(TOOLS_LV_TOOL)
 
-EXTRA_PROGRAMS = lv-tool
+EXTRA_PROGRAMS = lv-tool-0.4
 
-lv_tool_SOURCES = lv-tool.cpp
-lv_tool_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/libvisual
-lv_tool_CXXFLAGS = $(SDL_CFLAGS)
-lv_tool_LDADD = $(SDL_LIBS) ../../libvisual/libvisual-@LIBVISUAL_VERSION_SUFFIX@.la
+lv_tool_0_4_SOURCES = lv-tool.cpp
+lv_tool_0_4_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/libvisual
+lv_tool_0_4_CXXFLAGS = $(SDL_CFLAGS)
+lv_tool_0_4_LDADD = $(SDL_LIBS) ../../libvisual/libvisual-@LIBVISUAL_VERSION_SUFFIX@.la


### PR DESCRIPTION
@kaixiong this conflicts with #232 but I'm happy to rebase either side onto whatever gets merged first.
The idea is to better fit into the `libvisual-0.4` naming worlds and with the option to have two libvisual lv-tools side by side at some point. Inspired by gstreamer.