### PR TITLE
[0.4.x] lv-tool: Increase initial/default resolution from 320x200 to 640x480

### DIFF
--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -41,8 +41,8 @@
 #define DEFAULT_ACTOR_GL "lv_gltest"
 #define DEFAULT_ACTOR_NONGL "lv_analyzer"
 #define DEFAULT_INPUT   "debug"
-#define DEFAULT_WIDTH   320
-#define DEFAULT_HEIGHT  200
+#define DEFAULT_WIDTH   640
+#define DEFAULT_HEIGHT  480
 #define DEFAULT_FPS     60
 #define DEFAULT_COLOR_DEPTH 0
 
@@ -597,7 +597,7 @@ namespace {
               case 'D': {
                   if (std::sscanf (optarg, "%ux%u", &width, &height) != 2)
                   {
-                      std::cerr << "Invalid dimensions: '" << optarg << "'. Use <width>x<height> (e.g. 320x200)\n";
+                      std::cerr << "Invalid dimensions: '" << optarg << "'. Use <width>x<height> (e.g. 640x480)\n";
                       return -1;
                   }
                   break;


### PR DESCRIPTION
@kaixiong it is meant to be a conservative increase and be smaller than a quarter of 1920x1080. The idea is to just show a bit more: 320x200 is just crazy tiny these days.