### PR TITLE
[0.4.x] libvisual-plugins: Fix flipped assertion in .init of input "portaudio"

### DIFF
--- a/libvisual-plugins/plugins/input/portaudio/input_portaudio.c
+++ b/libvisual-plugins/plugins/input/portaudio/input_portaudio.c
@@ -103,7 +103,7 @@ int inp_portaudio_init (VisPluginData *plugin)
 	const PaError open_error =
 			Pa_OpenStream (&priv->stream, &input_parameters, NULL,
 						   SAMPLE_RATE, FRAMES, paClipOff, NULL, NULL);
-	visual_log_return_val_if_fail (open_error != paNoError, -3);
+	visual_log_return_val_if_fail (open_error == paNoError, -3);
 
 	// Allocate buffer
 	const visual_size_t buffer_size_bytes = FRAMES * CHANNELS * (SAMPLE_FORMAT_BITS / 8);


### PR DESCRIPTION
Regression from #236, `master`'s #234 turned out unaffected.