### PR TITLE
lv-tool: Debounce resize requests (fixes #161)

### DIFF
--- a/libvisual/tools/lv-tool/display/sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/sdl_driver.cpp
@@ -285,8 +285,6 @@ namespace {
                   visual_event_queue_add (&eventqueue,
                                           visual_event_new_resize (event.resize.w,
                                                                    event.resize.h));
-
-                  create (m_display.get_video ()->get_depth (), nullptr, event.resize.w, event.resize.h, m_resizable);
                   break;
 
               case SDL_MOUSEMOTION:

--- a/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
@@ -330,8 +330,6 @@ namespace {
                       visual_event_queue_add (&eventqueue,
                                               visual_event_new_resize (event.resize.w,
                                                                        event.resize.h));
-
-                      create (m_display.get_video ()->get_depth (), nullptr, event.resize.w, event.resize.h, m_resizable);
                       break;
 
                   case SDL_MOUSEMOTION:


### PR DESCRIPTION
Fixes #161

Forward-port of 0.4.x pull requests #210 and #249

~@kaixiong turns out that with enough mouse action over a longer period, I could still reproduce the stutter. That's why it's combined with dropping stale events now for a more complete fix, needs a backport to 0.4.x.~