### PR TITLE
Core: Add LV_NODISCARD for C API functions with non-discardable results  

### DIFF
--- a/libvisual/libvisual/lv_actor.h
+++ b/libvisual/libvisual/lv_actor.h
@@ -248,7 +248,7 @@ LV_API const char *visual_actor_get_next_by_name_nogl (const char *name);
 LV_API const char *visual_actor_get_prev_by_name      (const char *name);
 LV_API const char *visual_actor_get_next_by_name      (const char *name);
 
-LV_API LV_NODISCARD VisActor *visual_actor_new (const char *name);
+LV_NODISCARD LV_API VisActor *visual_actor_new (const char *name);
 LV_API int  visual_actor_realize (VisActor *actor);
 LV_API void visual_actor_run     (VisActor *actor, VisAudio *audio);
 LV_API void visual_actor_ref     (VisActor *actor);

--- a/libvisual/libvisual/lv_actor.h
+++ b/libvisual/libvisual/lv_actor.h
@@ -248,11 +248,11 @@ LV_API const char *visual_actor_get_next_by_name_nogl (const char *name);
 LV_API const char *visual_actor_get_prev_by_name      (const char *name);
 LV_API const char *visual_actor_get_next_by_name      (const char *name);
 
-LV_API VisActor *visual_actor_new     (const char *name);
-LV_API int       visual_actor_realize (VisActor *actor);
-LV_API void      visual_actor_run     (VisActor *actor, VisAudio *audio);
-LV_API void      visual_actor_ref     (VisActor *actor);
-LV_API void      visual_actor_unref   (VisActor *actor);
+LV_API LV_NODISCARD VisActor *visual_actor_new (const char *name);
+LV_API int  visual_actor_realize (VisActor *actor);
+LV_API void visual_actor_run     (VisActor *actor, VisAudio *audio);
+LV_API void visual_actor_ref     (VisActor *actor);
+LV_API void visual_actor_unref   (VisActor *actor);
 
 LV_API VisSongInfo *visual_actor_get_songinfo (VisActor *actor);
 LV_API VisPalette  *visual_actor_get_palette  (VisActor *actor);

--- a/libvisual/libvisual/lv_audio.h
+++ b/libvisual/libvisual/lv_audio.h
@@ -218,7 +218,8 @@ struct _VisAudio;
 
 LV_BEGIN_DECLS
 
-LV_API VisAudio *visual_audio_new (void);
+LV_API LV_NODISCARD VisAudio *visual_audio_new (void);
+
 LV_API void visual_audio_free (VisAudio *audio);
 
 LV_API int  visual_audio_get_sample (VisAudio *audio, VisBuffer *buffer, const char *channelid);

--- a/libvisual/libvisual/lv_audio.h
+++ b/libvisual/libvisual/lv_audio.h
@@ -218,7 +218,7 @@ struct _VisAudio;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisAudio *visual_audio_new (void);
+LV_NODISCARD LV_API VisAudio *visual_audio_new (void);
 
 LV_API void visual_audio_free (VisAudio *audio);
 

--- a/libvisual/libvisual/lv_bin.h
+++ b/libvisual/libvisual/lv_bin.h
@@ -121,7 +121,7 @@ struct _VisBin;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisBin *visual_bin_new (void);
+LV_NODISCARD LV_API VisBin *visual_bin_new (void);
 
 LV_API void visual_bin_free (VisBin *bin);
 

--- a/libvisual/libvisual/lv_bin.h
+++ b/libvisual/libvisual/lv_bin.h
@@ -121,8 +121,9 @@ struct _VisBin;
 
 LV_BEGIN_DECLS
 
-LV_API VisBin *visual_bin_new (void);
-LV_API void    visual_bin_free (VisBin *bin);
+LV_API LV_NODISCARD VisBin *visual_bin_new (void);
+
+LV_API void visual_bin_free (VisBin *bin);
 
 LV_API void visual_bin_realize (VisBin *bin);
 

--- a/libvisual/libvisual/lv_buffer.h
+++ b/libvisual/libvisual/lv_buffer.h
@@ -250,9 +250,9 @@ struct _VisBuffer;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisBuffer *visual_buffer_new_wrap_data (void *data, visual_size_t size, int own);
-LV_API LV_NODISCARD VisBuffer *visual_buffer_new_allocate  (visual_size_t size);
-LV_API LV_NODISCARD VisBuffer *visual_buffer_clone (VisBuffer *source);
+LV_NODISCARD LV_API VisBuffer *visual_buffer_new_wrap_data (void *data, visual_size_t size, int own);
+LV_NODISCARD LV_API VisBuffer *visual_buffer_new_allocate  (visual_size_t size);
+LV_NODISCARD LV_API VisBuffer *visual_buffer_clone (VisBuffer *source);
 
 LV_API void *visual_buffer_get_data (VisBuffer *buffer);
 LV_API void *visual_buffer_get_data_offset (VisBuffer *buffer, visual_size_t offset);

--- a/libvisual/libvisual/lv_buffer.h
+++ b/libvisual/libvisual/lv_buffer.h
@@ -250,9 +250,9 @@ struct _VisBuffer;
 
 LV_BEGIN_DECLS
 
-LV_API VisBuffer *visual_buffer_new_wrap_data (void *data, visual_size_t size, int own);
-LV_API VisBuffer *visual_buffer_new_allocate  (visual_size_t size);
-LV_API VisBuffer *visual_buffer_clone (VisBuffer *source);
+LV_API LV_NODISCARD VisBuffer *visual_buffer_new_wrap_data (void *data, visual_size_t size, int own);
+LV_API LV_NODISCARD VisBuffer *visual_buffer_new_allocate  (visual_size_t size);
+LV_API LV_NODISCARD VisBuffer *visual_buffer_clone (VisBuffer *source);
 
 LV_API void *visual_buffer_get_data (VisBuffer *buffer);
 LV_API void *visual_buffer_get_data_offset (VisBuffer *buffer, visual_size_t offset);

--- a/libvisual/libvisual/lv_color.h
+++ b/libvisual/libvisual/lv_color.h
@@ -147,9 +147,10 @@ struct _VisColor
 };
 #endif
 
-LV_API VisColor *visual_color_new   (void);
-LV_API VisColor *visual_color_clone (VisColor *color);
-LV_API void      visual_color_free  (VisColor *color);
+LV_API LV_NODISCARD VisColor *visual_color_new   (void);
+LV_API LV_NODISCARD VisColor *visual_color_clone (VisColor *color);
+
+LV_API void visual_color_free (VisColor *color);
 
 LV_API int visual_color_compare (VisColor *src1, VisColor *src2);
 

--- a/libvisual/libvisual/lv_color.h
+++ b/libvisual/libvisual/lv_color.h
@@ -147,8 +147,8 @@ struct _VisColor
 };
 #endif
 
-LV_API LV_NODISCARD VisColor *visual_color_new   (void);
-LV_API LV_NODISCARD VisColor *visual_color_clone (VisColor *color);
+LV_NODISCARD LV_API VisColor *visual_color_new   (void);
+LV_NODISCARD LV_API VisColor *visual_color_clone (VisColor *color);
 
 LV_API void visual_color_free (VisColor *color);
 

--- a/libvisual/libvisual/lv_defines.h
+++ b/libvisual/libvisual/lv_defines.h
@@ -120,7 +120,9 @@
   #define __PRETTY_FUNCTION__ __FUNCTION__
 #endif
 
-#ifdef _MSC_VER
+#ifdef __cplusplus
+  #define LV_NODISCARD [[nodiscard]]
+#elif defined(_MSC_VER)
   #define LV_NODISCARD _Check_return_
 #elif defined(__GNUC__)
   #define LV_NODISCARD  __attribute__ ((warn_unused_result))

--- a/libvisual/libvisual/lv_defines.h
+++ b/libvisual/libvisual/lv_defines.h
@@ -120,7 +120,7 @@
   #define __PRETTY_FUNCTION__ __FUNCTION__
 #endif
 
-#ifdef __cplusplus
+#if __cplusplus >= 201703L
   #define LV_NODISCARD [[nodiscard]]
 #elif defined(_MSC_VER) && _MSC_VER >= 1700
   #define LV_NODISCARD _Check_return_

--- a/libvisual/libvisual/lv_defines.h
+++ b/libvisual/libvisual/lv_defines.h
@@ -115,8 +115,17 @@
 #define LV_PLUGIN_EXPORT LV_DLL_EXPORT
 
 /* Utility macros */
+
 #ifdef _MSC_VER
   #define __PRETTY_FUNCTION__ __FUNCTION__
+#endif
+
+#ifdef _MSC_VER
+  #define LV_NODISCARD _Check_return_
+#elif defined(__GNUC__)
+  #define LV_NODISCARD  __attribute__ ((warn_unused_result))
+#else
+  #define LV_NODISCARD
 #endif
 
 #endif /* _LV_DEFINES_H */

--- a/libvisual/libvisual/lv_defines.h
+++ b/libvisual/libvisual/lv_defines.h
@@ -122,9 +122,9 @@
 
 #ifdef __cplusplus
   #define LV_NODISCARD [[nodiscard]]
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && _MSC_VER >= 1700
   #define LV_NODISCARD _Check_return_
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && __GNUC__ >= 4
   #define LV_NODISCARD  __attribute__ ((warn_unused_result))
 #else
   #define LV_NODISCARD

--- a/libvisual/libvisual/lv_event.h
+++ b/libvisual/libvisual/lv_event.h
@@ -237,7 +237,7 @@ LV_BEGIN_DECLS
  * @param keymod Key modifier used
  * @param state  State of key i.e. pressed or released
  */
-LV_API VisEvent *visual_event_new_keyboard (VisKey keysym, VisKeyMod keymod, VisKeyState state);
+LV_API LV_NODISCARD VisEvent *visual_event_new_keyboard (VisKey keysym, VisKeyMod keymod, VisKeyState state);
 
 /**
  * Creates a new mouse movement event.
@@ -247,7 +247,7 @@ LV_API VisEvent *visual_event_new_keyboard (VisKey keysym, VisKeyMod keymod, Vis
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_mousemotion (int dx, int dy);
+LV_API LV_NODISCARD VisEvent *visual_event_new_mousemotion (int dx, int dy);
 
 /**
  * Creates a new mouse button event
@@ -259,7 +259,7 @@ LV_API VisEvent *visual_event_new_mousemotion (int dx, int dy);
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_mousebutton (int button, VisMouseState state, int x, int y);
+LV_API LV_NODISCARD VisEvent *visual_event_new_mousebutton (int button, VisMouseState state, int x, int y);
 
 /**
  * Creates a resize event.
@@ -269,7 +269,7 @@ LV_API VisEvent *visual_event_new_mousebutton (int button, VisMouseState state, 
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_resize (int width, int height);
+LV_API LV_NODISCARD VisEvent *visual_event_new_resize (int width, int height);
 
 /**
  * Creates a new song change event.
@@ -278,7 +278,7 @@ LV_API VisEvent *visual_event_new_resize (int width, int height);
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_newsong (VisSongInfo *songinfo);
+LV_API LV_NODISCARD VisEvent *visual_event_new_newsong (VisSongInfo *songinfo);
 
 /**
  * Creates a new parameter change event.
@@ -287,14 +287,14 @@ LV_API VisEvent *visual_event_new_newsong (VisSongInfo *songinfo);
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_param (void *param);
+LV_API LV_NODISCARD VisEvent *visual_event_new_param (void *param);
 
 /**
  * Creates a quit event
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_quit (void);
+LV_API LV_NODISCARD VisEvent *visual_event_new_quit (void);
 
 /**
  * Creates a new visibility event.
@@ -303,7 +303,7 @@ LV_API VisEvent *visual_event_new_quit (void);
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_visibility (int is_visible);
+LV_API LV_NODISCARD VisEvent *visual_event_new_visibility (int is_visible);
 
 /**
  * Copies a VisEvent.
@@ -329,10 +329,11 @@ LV_API void visual_event_free (VisEvent* event);
  *
  * @return New event object
  */
-LV_API VisEvent *visual_event_new_custom (int eid, int param_int, void *param_ptr);
+LV_API LV_NODISCARD VisEvent *visual_event_new_custom (int eid, int param_int, void *param_ptr);
 
-LV_API VisEventQueue *visual_event_queue_new  (void);
-LV_API void           visual_event_queue_free (VisEventQueue *eventqueue);
+LV_API LV_NODISCARD VisEventQueue *visual_event_queue_new  (void);
+
+LV_API void visual_event_queue_free (VisEventQueue *eventqueue);
 
 LV_API void visual_event_queue_add  (VisEventQueue *eventqueue, VisEvent *event);
 LV_API int  visual_event_queue_poll (VisEventQueue *eventqueue, VisEvent *event);

--- a/libvisual/libvisual/lv_event.h
+++ b/libvisual/libvisual/lv_event.h
@@ -237,7 +237,7 @@ LV_BEGIN_DECLS
  * @param keymod Key modifier used
  * @param state  State of key i.e. pressed or released
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_keyboard (VisKey keysym, VisKeyMod keymod, VisKeyState state);
+LV_NODISCARD LV_API VisEvent *visual_event_new_keyboard (VisKey keysym, VisKeyMod keymod, VisKeyState state);
 
 /**
  * Creates a new mouse movement event.
@@ -247,7 +247,7 @@ LV_API LV_NODISCARD VisEvent *visual_event_new_keyboard (VisKey keysym, VisKeyMo
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_mousemotion (int dx, int dy);
+LV_NODISCARD LV_API VisEvent *visual_event_new_mousemotion (int dx, int dy);
 
 /**
  * Creates a new mouse button event
@@ -259,7 +259,7 @@ LV_API LV_NODISCARD VisEvent *visual_event_new_mousemotion (int dx, int dy);
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_mousebutton (int button, VisMouseState state, int x, int y);
+LV_NODISCARD LV_API VisEvent *visual_event_new_mousebutton (int button, VisMouseState state, int x, int y);
 
 /**
  * Creates a resize event.
@@ -269,7 +269,7 @@ LV_API LV_NODISCARD VisEvent *visual_event_new_mousebutton (int button, VisMouse
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_resize (int width, int height);
+LV_NODISCARD LV_API VisEvent *visual_event_new_resize (int width, int height);
 
 /**
  * Creates a new song change event.
@@ -278,7 +278,7 @@ LV_API LV_NODISCARD VisEvent *visual_event_new_resize (int width, int height);
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_newsong (VisSongInfo *songinfo);
+LV_NODISCARD LV_API VisEvent *visual_event_new_newsong (VisSongInfo *songinfo);
 
 /**
  * Creates a new parameter change event.
@@ -287,14 +287,14 @@ LV_API LV_NODISCARD VisEvent *visual_event_new_newsong (VisSongInfo *songinfo);
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_param (void *param);
+LV_NODISCARD LV_API VisEvent *visual_event_new_param (void *param);
 
 /**
  * Creates a quit event
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_quit (void);
+LV_NODISCARD LV_API VisEvent *visual_event_new_quit (void);
 
 /**
  * Creates a new visibility event.
@@ -303,7 +303,7 @@ LV_API LV_NODISCARD VisEvent *visual_event_new_quit (void);
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_visibility (int is_visible);
+LV_NODISCARD LV_API VisEvent *visual_event_new_visibility (int is_visible);
 
 /**
  * Copies a VisEvent.
@@ -329,9 +329,9 @@ LV_API void visual_event_free (VisEvent* event);
  *
  * @return New event object
  */
-LV_API LV_NODISCARD VisEvent *visual_event_new_custom (int eid, int param_int, void *param_ptr);
+LV_NODISCARD LV_API VisEvent *visual_event_new_custom (int eid, int param_int, void *param_ptr);
 
-LV_API LV_NODISCARD VisEventQueue *visual_event_queue_new  (void);
+LV_NODISCARD LV_API VisEventQueue *visual_event_queue_new  (void);
 
 LV_API void visual_event_queue_free (VisEventQueue *eventqueue);
 

--- a/libvisual/libvisual/lv_fourier.h
+++ b/libvisual/libvisual/lv_fourier.h
@@ -133,8 +133,9 @@ struct _VisDFT;
 
 LV_BEGIN_DECLS
 
-LV_API VisDFT *visual_dft_new  (unsigned int samples_out, unsigned int samples_in);
-LV_API void    visual_dft_free (VisDFT *dft);
+LV_API LV_NODISCARD VisDFT *visual_dft_new  (unsigned int samples_out, unsigned int samples_in);
+
+LV_API void visual_dft_free (VisDFT *dft);
 
 LV_API void visual_dft_perform (VisDFT *dft, float *output, float const *input);
 

--- a/libvisual/libvisual/lv_fourier.h
+++ b/libvisual/libvisual/lv_fourier.h
@@ -133,7 +133,7 @@ struct _VisDFT;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisDFT *visual_dft_new  (unsigned int samples_out, unsigned int samples_in);
+LV_NODISCARD LV_API VisDFT *visual_dft_new  (unsigned int samples_out, unsigned int samples_in);
 
 LV_API void visual_dft_free (VisDFT *dft);
 

--- a/libvisual/libvisual/lv_input.h
+++ b/libvisual/libvisual/lv_input.h
@@ -179,11 +179,12 @@ struct _VisInputPlugin {
 
 LV_BEGIN_DECLS
 
-LV_API VisInput *visual_input_new     (const char *name);
-LV_API void      visual_input_ref     (VisInput *input);
-LV_API void      visual_input_unref   (VisInput *input);
-LV_API int       visual_input_realize (VisInput *input);
-LV_API int       visual_input_run     (VisInput *input);
+LV_API LV_NODISCARD VisInput *visual_input_new (const char *name);
+
+LV_API void visual_input_ref     (VisInput *input);
+LV_API void visual_input_unref   (VisInput *input);
+LV_API int  visual_input_realize (VisInput *input);
+LV_API int  visual_input_run     (VisInput *input);
 
 LV_API VisPluginData *visual_input_get_plugin  (VisInput *input);
 LV_API VisAudio      *visual_input_get_audio    (VisInput *audio);

--- a/libvisual/libvisual/lv_input.h
+++ b/libvisual/libvisual/lv_input.h
@@ -179,7 +179,7 @@ struct _VisInputPlugin {
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisInput *visual_input_new (const char *name);
+LV_NODISCARD LV_API VisInput *visual_input_new (const char *name);
 
 LV_API void visual_input_ref     (VisInput *input);
 LV_API void visual_input_unref   (VisInput *input);

--- a/libvisual/libvisual/lv_mem.h
+++ b/libvisual/libvisual/lv_mem.h
@@ -98,7 +98,7 @@ LV_BEGIN_DECLS
  *
  * @return Pointer to newly allocated memory block, or NULL on failure
  */
-LV_API void *visual_mem_malloc (visual_size_t size) LV_ATTR_MALLOC;
+LV_API LV_NODISCARD void *visual_mem_malloc (visual_size_t size) LV_ATTR_MALLOC;
 
 /**
  * Allocates a block of memory with its content zeroed.
@@ -108,7 +108,7 @@ LV_API void *visual_mem_malloc (visual_size_t size) LV_ATTR_MALLOC;
  * @return Pointer to newly allocated memory block with its contents
  * zeroed, or NULL on failure
  */
-LV_API void *visual_mem_malloc0 (visual_size_t size) LV_ATTR_MALLOC;
+LV_API LV_NODISCARD void *visual_mem_malloc0 (visual_size_t size) LV_ATTR_MALLOC;
 
 /**
  * Reallocates memory, can be used to grow a buffer.
@@ -118,7 +118,7 @@ LV_API void *visual_mem_malloc0 (visual_size_t size) LV_ATTR_MALLOC;
  *
  * @return pointer to the reallocated memory block, or NULL on failure
  */
-LV_API void *visual_mem_realloc (void *ptr, visual_size_t size) LV_ATTR_MALLOC;
+LV_API LV_NODISCARD void *visual_mem_realloc (void *ptr, visual_size_t size) LV_ATTR_MALLOC;
 
 /**
  * Frees a memory block allocated by visual_mem_malloc() and visual_mem_realloc().
@@ -139,7 +139,7 @@ LV_API void visual_mem_free (void *ptr);
  *
  * @note Memory allocated by this function must be fred by visual_mem_free_aligned().
  */
-LV_API void *visual_mem_malloc_aligned (visual_size_t size, visual_size_t alignment);
+LV_API LV_NODISCARD void *visual_mem_malloc_aligned (visual_size_t size, visual_size_t alignment);
 
 /**
  * Frees a memory block allocated by visual_mem_alloc_aligned().

--- a/libvisual/libvisual/lv_mem.h
+++ b/libvisual/libvisual/lv_mem.h
@@ -98,7 +98,7 @@ LV_BEGIN_DECLS
  *
  * @return Pointer to newly allocated memory block, or NULL on failure
  */
-LV_API LV_NODISCARD void *visual_mem_malloc (visual_size_t size) LV_ATTR_MALLOC;
+LV_NODISCARD LV_API void *visual_mem_malloc (visual_size_t size) LV_ATTR_MALLOC;
 
 /**
  * Allocates a block of memory with its content zeroed.
@@ -108,7 +108,7 @@ LV_API LV_NODISCARD void *visual_mem_malloc (visual_size_t size) LV_ATTR_MALLOC;
  * @return Pointer to newly allocated memory block with its contents
  * zeroed, or NULL on failure
  */
-LV_API LV_NODISCARD void *visual_mem_malloc0 (visual_size_t size) LV_ATTR_MALLOC;
+LV_NODISCARD LV_API void *visual_mem_malloc0 (visual_size_t size) LV_ATTR_MALLOC;
 
 /**
  * Reallocates memory, can be used to grow a buffer.
@@ -118,7 +118,7 @@ LV_API LV_NODISCARD void *visual_mem_malloc0 (visual_size_t size) LV_ATTR_MALLOC
  *
  * @return pointer to the reallocated memory block, or NULL on failure
  */
-LV_API LV_NODISCARD void *visual_mem_realloc (void *ptr, visual_size_t size) LV_ATTR_MALLOC;
+LV_NODISCARD LV_API void *visual_mem_realloc (void *ptr, visual_size_t size) LV_ATTR_MALLOC;
 
 /**
  * Frees a memory block allocated by visual_mem_malloc() and visual_mem_realloc().
@@ -139,7 +139,7 @@ LV_API void visual_mem_free (void *ptr);
  *
  * @note Memory allocated by this function must be fred by visual_mem_free_aligned().
  */
-LV_API LV_NODISCARD void *visual_mem_malloc_aligned (visual_size_t size, visual_size_t alignment);
+LV_NODISCARD LV_API void *visual_mem_malloc_aligned (visual_size_t size, visual_size_t alignment);
 
 /**
  * Frees a memory block allocated by visual_mem_alloc_aligned().

--- a/libvisual/libvisual/lv_morph.h
+++ b/libvisual/libvisual/lv_morph.h
@@ -262,7 +262,7 @@ LV_API const char *visual_morph_get_next_by_name (const char *name);
  */
 LV_API const char *visual_morph_get_prev_by_name (const char *name);
 
-LV_API LV_NODISCARD VisMorph *visual_morph_new (const char *name);
+LV_NODISCARD LV_API VisMorph *visual_morph_new (const char *name);
 
 LV_API void visual_morph_ref   (VisMorph *morph);
 LV_API void visual_morph_unref (VisMorph *morph);

--- a/libvisual/libvisual/lv_morph.h
+++ b/libvisual/libvisual/lv_morph.h
@@ -262,9 +262,10 @@ LV_API const char *visual_morph_get_next_by_name (const char *name);
  */
 LV_API const char *visual_morph_get_prev_by_name (const char *name);
 
-LV_API VisMorph *visual_morph_new   (const char *name);
-LV_API void      visual_morph_ref   (VisMorph *morph);
-LV_API void      visual_morph_unref (VisMorph *morph);
+LV_API LV_NODISCARD VisMorph *visual_morph_new (const char *name);
+
+LV_API void visual_morph_ref   (VisMorph *morph);
+LV_API void visual_morph_unref (VisMorph *morph);
 
 LV_API VisPluginData       *visual_morph_get_plugin                  (VisMorph *morph);
 LV_API VisVideoDepth        visual_morph_get_supported_depths        (VisMorph *morph);

--- a/libvisual/libvisual/lv_palette.h
+++ b/libvisual/libvisual/lv_palette.h
@@ -127,7 +127,7 @@ struct _VisPalette;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisPalette *visual_palette_new (unsigned int ncolors);
+LV_NODISCARD LV_API VisPalette *visual_palette_new (unsigned int ncolors);
 
 LV_API void visual_palette_free (VisPalette *palette);
 

--- a/libvisual/libvisual/lv_palette.h
+++ b/libvisual/libvisual/lv_palette.h
@@ -127,7 +127,7 @@ struct _VisPalette;
 
 LV_BEGIN_DECLS
 
-LV_API VisPalette *visual_palette_new (unsigned int ncolors);
+LV_API LV_NODISCARD VisPalette *visual_palette_new (unsigned int ncolors);
 
 LV_API void visual_palette_free (VisPalette *palette);
 

--- a/libvisual/libvisual/lv_palette.h
+++ b/libvisual/libvisual/lv_palette.h
@@ -129,9 +129,9 @@ LV_BEGIN_DECLS
 
 LV_NODISCARD LV_API VisPalette *visual_palette_new (unsigned int ncolors);
 
-LV_API void visual_palette_free (VisPalette *palette);
+LV_NODISCARD LV_API VisPalette *visual_palette_clone (VisPalette *self);
 
-LV_API VisPalette *visual_palette_clone (VisPalette *self);
+LV_API void visual_palette_free (VisPalette *palette);
 
 LV_API void visual_palette_copy (VisPalette *dest, VisPalette *src);
 

--- a/libvisual/libvisual/lv_param.h
+++ b/libvisual/libvisual/lv_param.h
@@ -159,13 +159,14 @@ LV_BEGIN_DECLS
 
 /* VisClosure API */
 
-LV_API VisClosure *visual_closure_new  (void *func, void *data, VisDestroyFunc destroy_func);
-LV_API void        visual_closure_free (VisClosure *self);
+LV_API LV_NODISCARD VisClosure *visual_closure_new (void *func, void *data, VisDestroyFunc destroy_func);
+
+LV_API void visual_closure_free (VisClosure *self);
 
 /* VisParamList API */
 
-LV_API VisParamList *visual_param_list_new  (void);
-LV_API void          visual_param_list_free (VisParamList *self);
+LV_API LV_NODISCARD VisParamList *visual_param_list_new  (void);
+LV_API void visual_param_list_free (VisParamList *self);
 
 LV_API void         visual_param_list_add         (VisParamList *list, VisParam *param);
 LV_API void         visual_param_list_add_array   (VisParamList *list, VisParam **params, unsigned int nparams);
@@ -190,11 +191,11 @@ LV_API VisEventQueue *visual_param_list_get_event_queue (VisParamList *list);
  *
  * @return A newly allocated VisParam
  */
-LV_API VisParam *visual_param_new (const char * name,
-                                   const char * description,
-                                   VisParamType type,
-                                   void *       default_value,
-                                   VisClosure * validator);
+LV_API LV_NODISCARD VisParam *visual_param_new (const char * name,
+                                                const char * description,
+                                                VisParamType type,
+                                                void *       default_value,
+                                                VisClosure * validator);
 
 /**
  * Frees a parameter entry.

--- a/libvisual/libvisual/lv_param.h
+++ b/libvisual/libvisual/lv_param.h
@@ -159,13 +159,14 @@ LV_BEGIN_DECLS
 
 /* VisClosure API */
 
-LV_API LV_NODISCARD VisClosure *visual_closure_new (void *func, void *data, VisDestroyFunc destroy_func);
+LV_NODISCARD LV_API VisClosure *visual_closure_new (void *func, void *data, VisDestroyFunc destroy_func);
 
 LV_API void visual_closure_free (VisClosure *self);
 
 /* VisParamList API */
 
-LV_API LV_NODISCARD VisParamList *visual_param_list_new  (void);
+LV_NODISCARD LV_API VisParamList *visual_param_list_new  (void);
+
 LV_API void visual_param_list_free (VisParamList *self);
 
 LV_API void         visual_param_list_add         (VisParamList *list, VisParam *param);
@@ -191,7 +192,7 @@ LV_API VisEventQueue *visual_param_list_get_event_queue (VisParamList *list);
  *
  * @return A newly allocated VisParam
  */
-LV_API LV_NODISCARD VisParam *visual_param_new (const char * name,
+LV_NODISCARD LV_API VisParam *visual_param_new (const char * name,
                                                 const char * description,
                                                 VisParamType type,
                                                 void *       default_value,

--- a/libvisual/libvisual/lv_param_validators.h
+++ b/libvisual/libvisual/lv_param_validators.h
@@ -23,7 +23,7 @@ typedef struct _VisClosure VisClosure;
 
 LV_BEGIN_DECLS
 
-LV_API VisClosure *visual_param_in_range (VisParamType type, void *lower, void *upper);
+LV_API LV_NODISCARD VisClosure *visual_param_in_range (VisParamType type, void *lower, void *upper);
 
 #define _LV_DEFINE_PARAM_IN_RANGE(func,ctype,type,marshal) \
     static inline VisClosure *visual_param_in_range_##func (ctype lower, ctype upper) { \

--- a/libvisual/libvisual/lv_param_validators.h
+++ b/libvisual/libvisual/lv_param_validators.h
@@ -23,7 +23,7 @@ typedef struct _VisClosure VisClosure;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisClosure *visual_param_in_range (VisParamType type, void *lower, void *upper);
+LV_NODISCARD LV_API VisClosure *visual_param_in_range (VisParamType type, void *lower, void *upper);
 
 #define _LV_DEFINE_PARAM_IN_RANGE(func,ctype,type,marshal) \
     static inline VisClosure *visual_param_in_range_##func (ctype lower, ctype upper) { \

--- a/libvisual/libvisual/lv_param_value.h
+++ b/libvisual/libvisual/lv_param_value.h
@@ -59,13 +59,14 @@ struct _VisParamValue
 
 LV_BEGIN_DECLS
 
-LV_API VisParamValue *visual_param_value_new        (VisParamType   type, void *value);
-LV_API void           visual_param_value_init       (VisParamValue *self, VisParamType type, void *value);
-LV_API void           visual_param_value_copy       (VisParamValue *value, VisParamValue *src);
-LV_API void           visual_param_value_set        (VisParamValue *value, VisParamType type, void *new_value);
-LV_API int            visual_param_value_compare    (VisParamValue *lhs, VisParamValue *rhs);
-LV_API void           visual_param_value_free       (VisParamValue *value);
-LV_API void           visual_param_value_free_value (VisParamValue *value);
+LV_NODISCARD LV_API VisParamValue *visual_param_value_new (VisParamType type, void *value);
+
+LV_API void visual_param_value_init       (VisParamValue *self, VisParamType type, void *value);
+LV_API void visual_param_value_copy       (VisParamValue *value, VisParamValue *src);
+LV_API void visual_param_value_set        (VisParamValue *value, VisParamType type, void *new_value);
+LV_API int  visual_param_value_compare    (VisParamValue *lhs, VisParamValue *rhs);
+LV_API void visual_param_value_free       (VisParamValue *value);
+LV_API void visual_param_value_free_value (VisParamValue *value);
 
 #define _LV_PARAM_MARSHAL_INTEGER(x)   ((void *) (intptr_t) (x))
 #define _LV_PARAM_MARSHAL_FLOAT(x)     ((void *) (&x))

--- a/libvisual/libvisual/lv_random.h
+++ b/libvisual/libvisual/lv_random.h
@@ -139,7 +139,7 @@ typedef ::LV::RandomSeed    VisRandomSeed;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisRandomContext *visual_random_context_new  (VisRandomSeed seed);
+LV_NODISCARD LV_API VisRandomContext *visual_random_context_new  (VisRandomSeed seed);
 
 LV_API void visual_random_context_free (VisRandomContext *rcontext);
 

--- a/libvisual/libvisual/lv_random.h
+++ b/libvisual/libvisual/lv_random.h
@@ -139,8 +139,9 @@ typedef ::LV::RandomSeed    VisRandomSeed;
 
 LV_BEGIN_DECLS
 
-LV_API VisRandomContext *visual_random_context_new  (VisRandomSeed seed);
-LV_API void              visual_random_context_free (VisRandomContext *rcontext);
+LV_API LV_NODISCARD VisRandomContext *visual_random_context_new  (VisRandomSeed seed);
+
+LV_API void visual_random_context_free (VisRandomContext *rcontext);
 
 LV_API void     visual_random_context_set_seed  (VisRandomContext *rcontext, VisRandomSeed seed);
 LV_API uint32_t visual_random_context_int       (VisRandomContext *rcontext);

--- a/libvisual/libvisual/lv_rectangle.h
+++ b/libvisual/libvisual/lv_rectangle.h
@@ -251,15 +251,15 @@ struct _VisRectangle;
 
 LV_BEGIN_DECLS
 
-LV_API VisRectangle *visual_rectangle_new (int x, int y, int width, int height);
-LV_API VisRectangle *visual_rectangle_new_empty (void);
+LV_API LV_NODISCARD VisRectangle *visual_rectangle_new (int x, int y, int width, int height);
+LV_API LV_NODISCARD VisRectangle *visual_rectangle_new_empty (void);
 
 LV_API void visual_rectangle_free (VisRectangle *rect);
 
 LV_API void visual_rectangle_set  (VisRectangle *rect, int x, int y, int width, int height);
 LV_API void visual_rectangle_copy (VisRectangle *dest, VisRectangle *src);
 
-LV_API VisRectangle *visual_rectangle_clone (VisRectangle *rect);
+LV_API LV_NODISCARD VisRectangle *visual_rectangle_clone (VisRectangle *rect);
 
 LV_API void visual_rectangle_set_x      (VisRectangle *rect, int x);
 LV_API int  visual_rectangle_get_x      (VisRectangle *rect);

--- a/libvisual/libvisual/lv_rectangle.h
+++ b/libvisual/libvisual/lv_rectangle.h
@@ -251,15 +251,15 @@ struct _VisRectangle;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisRectangle *visual_rectangle_new (int x, int y, int width, int height);
-LV_API LV_NODISCARD VisRectangle *visual_rectangle_new_empty (void);
+LV_NODISCARD LV_API VisRectangle *visual_rectangle_new (int x, int y, int width, int height);
+LV_NODISCARD LV_API VisRectangle *visual_rectangle_new_empty (void);
 
 LV_API void visual_rectangle_free (VisRectangle *rect);
 
 LV_API void visual_rectangle_set  (VisRectangle *rect, int x, int y, int width, int height);
 LV_API void visual_rectangle_copy (VisRectangle *dest, VisRectangle *src);
 
-LV_API LV_NODISCARD VisRectangle *visual_rectangle_clone (VisRectangle *rect);
+LV_NODISCARD LV_API VisRectangle *visual_rectangle_clone (VisRectangle *rect);
 
 LV_API void visual_rectangle_set_x      (VisRectangle *rect, int x);
 LV_API int  visual_rectangle_get_x      (VisRectangle *rect);

--- a/libvisual/libvisual/lv_songinfo.h
+++ b/libvisual/libvisual/lv_songinfo.h
@@ -214,8 +214,8 @@ struct _VisSongInfo;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisSongInfo *visual_songinfo_new   (VisSongInfoType type);
-LV_API LV_NODISCARD VisSongInfo *visual_songinfo_clone (VisSongInfo const *src);
+LV_NODISCARD LV_API VisSongInfo *visual_songinfo_new   (VisSongInfoType type);
+LV_NODISCARD LV_API VisSongInfo *visual_songinfo_clone (VisSongInfo const *src);
 
 LV_API void visual_songinfo_free (VisSongInfo *songinfo);
 

--- a/libvisual/libvisual/lv_songinfo.h
+++ b/libvisual/libvisual/lv_songinfo.h
@@ -214,9 +214,10 @@ struct _VisSongInfo;
 
 LV_BEGIN_DECLS
 
-LV_API VisSongInfo *visual_songinfo_new   (VisSongInfoType type);
-LV_API VisSongInfo *visual_songinfo_clone (VisSongInfo const *src);
-LV_API void         visual_songinfo_free  (VisSongInfo *songinfo);
+LV_API LV_NODISCARD VisSongInfo *visual_songinfo_new   (VisSongInfoType type);
+LV_API LV_NODISCARD VisSongInfo *visual_songinfo_clone (VisSongInfo const *src);
+
+LV_API void visual_songinfo_free (VisSongInfo *songinfo);
 
 LV_API void visual_songinfo_copy    (VisSongInfo *dest, VisSongInfo const *src);
 LV_API int  visual_songinfo_compare (VisSongInfo const *s1, VisSongInfo const *s2);

--- a/libvisual/libvisual/lv_time.h
+++ b/libvisual/libvisual/lv_time.h
@@ -228,10 +228,10 @@ struct _VisTimer;
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisTime *visual_time_new             (void);
-LV_API LV_NODISCARD VisTime *visual_time_new_now         (void);
-LV_API LV_NODISCARD VisTime *visual_time_new_with_values (long sec, long nsec);
-LV_API LV_NODISCARD VisTime *visual_time_clone           (VisTime *src);
+LV_NODISCARD LV_API VisTime *visual_time_new             (void);
+LV_NODISCARD LV_API VisTime *visual_time_new_now         (void);
+LV_NODISCARD LV_API VisTime *visual_time_new_with_values (long sec, long nsec);
+LV_NODISCARD LV_API VisTime *visual_time_clone           (VisTime *src);
 
 LV_API void visual_time_free (VisTime *time_);
 

--- a/libvisual/libvisual/lv_time.h
+++ b/libvisual/libvisual/lv_time.h
@@ -250,8 +250,9 @@ LV_API void visual_usleep (uint64_t usecs);
 
 LV_API void visual_time_set_from_msecs (VisTime *time_, uint64_t msecs);
 
-LV_API VisTimer *visual_timer_new  (void);
-LV_API void      visual_timer_free (VisTimer *timer);
+LV_NODISCARD LV_API VisTimer *visual_timer_new (void);
+
+LV_API void visual_timer_free (VisTimer *timer);
 
 LV_API void visual_timer_reset     (VisTimer *timer);
 LV_API void visual_timer_start     (VisTimer *timer);

--- a/libvisual/libvisual/lv_time.h
+++ b/libvisual/libvisual/lv_time.h
@@ -24,6 +24,7 @@
 #ifndef _LV_TIME_H
 #define _LV_TIME_H
 
+#include "lv_defines.h"
 #include <libvisual/lv_types.h>
 #include <time.h>
 
@@ -227,11 +228,12 @@ struct _VisTimer;
 
 LV_BEGIN_DECLS
 
-LV_API VisTime *visual_time_new             (void);
-LV_API VisTime *visual_time_new_now         (void);
-LV_API VisTime *visual_time_new_with_values (long sec, long nsec);
-LV_API VisTime *visual_time_clone           (VisTime *src);
-LV_API void     visual_time_free            (VisTime *time_);
+LV_API LV_NODISCARD VisTime *visual_time_new             (void);
+LV_API LV_NODISCARD VisTime *visual_time_new_now         (void);
+LV_API LV_NODISCARD VisTime *visual_time_new_with_values (long sec, long nsec);
+LV_API LV_NODISCARD VisTime *visual_time_clone           (VisTime *src);
+
+LV_API void visual_time_free (VisTime *time_);
 
 LV_API void visual_time_set     (VisTime *time_, long sec, long usec);
 LV_API void visual_time_copy    (VisTime *dest, VisTime *src);

--- a/libvisual/libvisual/lv_time.h
+++ b/libvisual/libvisual/lv_time.h
@@ -24,7 +24,7 @@
 #ifndef _LV_TIME_H
 #define _LV_TIME_H
 
-#include "lv_defines.h"
+#include <libvisual/lv_defines.h>
 #include <libvisual/lv_types.h>
 #include <time.h>
 

--- a/libvisual/libvisual/lv_util.h
+++ b/libvisual/libvisual/lv_util.h
@@ -5,7 +5,7 @@
 
 LV_BEGIN_DECLS
 
-LV_API char *visual_strdup (const char *s);
+LV_API LV_NODISCARD char *visual_strdup (const char *s);
 
 LV_API const char *visual_truncate_path (const char* filename, unsigned int parts);
 

--- a/libvisual/libvisual/lv_util.h
+++ b/libvisual/libvisual/lv_util.h
@@ -5,7 +5,7 @@
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD char *visual_strdup (const char *s);
+LV_NODISCARD LV_API char *visual_strdup (const char *s);
 
 LV_API const char *visual_truncate_path (const char* filename, unsigned int parts);
 

--- a/libvisual/libvisual/lv_video.h
+++ b/libvisual/libvisual/lv_video.h
@@ -508,10 +508,10 @@ namespace LV {
 
 LV_BEGIN_DECLS
 
-LV_API LV_NODISCARD VisVideo *visual_video_new (void);
-LV_API LV_NODISCARD VisVideo *visual_video_new_with_buffer (int width, int height, VisVideoDepth depth);
-LV_API LV_NODISCARD VisVideo *visual_video_new_wrap_buffer (void *buffer, int owner, int width, int height, VisVideoDepth depth, int pitch);
-LV_API LV_NODISCARD VisVideo *visual_video_load_from_file  (const char *path);
+LV_NODISCARD LV_API VisVideo *visual_video_new (void);
+LV_NODISCARD LV_API VisVideo *visual_video_new_with_buffer (int width, int height, VisVideoDepth depth);
+LV_NODISCARD LV_API VisVideo *visual_video_new_wrap_buffer (void *buffer, int owner, int width, int height, VisVideoDepth depth, int pitch);
+LV_NODISCARD LV_API VisVideo *visual_video_load_from_file  (const char *path);
 
 LV_API void visual_video_ref   (VisVideo *video);
 LV_API void visual_video_unref (VisVideo *video);
@@ -540,12 +540,12 @@ LV_API void *visual_video_get_pixel_ptr (VisVideo *video, int x, int y);
 
 LV_API VisBuffer *visual_video_get_buffer (VisVideo *video);
 
-LV_API LV_NODISCARD VisRectangle *visual_video_get_extents (VisVideo *video);
+LV_NODISCARD LV_API VisRectangle *visual_video_get_extents (VisVideo *video);
 
-LV_API LV_NODISCARD VisVideo *visual_video_new_sub (VisVideo *src, VisRectangle *area);
-LV_API LV_NODISCARD VisVideo *visual_video_new_sub_by_values (VisVideo *src, int x, int y, int width, int height);
-LV_API LV_NODISCARD VisVideo *visual_video_new_sub_with_boundary (VisRectangle *drect, VisVideo *src, VisRectangle *srect);
-LV_API LV_NODISCARD VisVideo *visual_video_new_sub_all (VisVideo *src);
+LV_NODISCARD LV_API VisVideo *visual_video_new_sub (VisVideo *src, VisRectangle *area);
+LV_NODISCARD LV_API VisVideo *visual_video_new_sub_by_values (VisVideo *src, int x, int y, int width, int height);
+LV_NODISCARD LV_API VisVideo *visual_video_new_sub_with_boundary (VisRectangle *drect, VisVideo *src, VisRectangle *srect);
+LV_NODISCARD LV_API VisVideo *visual_video_new_sub_all (VisVideo *src);
 
 LV_API void visual_video_set_compose_type     (VisVideo *video, VisVideoComposeType type);
 LV_API void visual_video_set_compose_colorkey (VisVideo *video, VisColor *color);
@@ -576,7 +576,7 @@ LV_API void visual_video_scale  (VisVideo *dest, VisVideo *src, VisVideoScaleMet
 
 LV_API void visual_video_scale_depth (VisVideo *dest, VisVideo *src, VisVideoScaleMethod scale_method);
 
-LV_API LV_NODISCARD VisVideo *visual_video_scale_depth_new (VisVideo*           src,
+LV_NODISCARD LV_API VisVideo *visual_video_scale_depth_new (VisVideo*           src,
                                                             int                 width,
                                                             int                 height,
                                                             VisVideoDepth       depth,

--- a/libvisual/libvisual/lv_video.h
+++ b/libvisual/libvisual/lv_video.h
@@ -508,10 +508,10 @@ namespace LV {
 
 LV_BEGIN_DECLS
 
-LV_API VisVideo *visual_video_new (void);
-LV_API VisVideo *visual_video_new_with_buffer (int width, int height, VisVideoDepth depth);
-LV_API VisVideo *visual_video_new_wrap_buffer (void *buffer, int owner, int width, int height, VisVideoDepth depth, int pitch);
-LV_API VisVideo *visual_video_load_from_file  (const char *path);
+LV_API LV_NODISCARD VisVideo *visual_video_new (void);
+LV_API LV_NODISCARD VisVideo *visual_video_new_with_buffer (int width, int height, VisVideoDepth depth);
+LV_API LV_NODISCARD VisVideo *visual_video_new_wrap_buffer (void *buffer, int owner, int width, int height, VisVideoDepth depth, int pitch);
+LV_API LV_NODISCARD VisVideo *visual_video_load_from_file  (const char *path);
 
 LV_API void visual_video_ref   (VisVideo *video);
 LV_API void visual_video_unref (VisVideo *video);
@@ -540,12 +540,12 @@ LV_API void *visual_video_get_pixel_ptr (VisVideo *video, int x, int y);
 
 LV_API VisBuffer *visual_video_get_buffer (VisVideo *video);
 
-LV_API VisRectangle *visual_video_get_extents (VisVideo *video);
+LV_API LV_NODISCARD VisRectangle *visual_video_get_extents (VisVideo *video);
 
-LV_API VisVideo *visual_video_new_sub (VisVideo *src, VisRectangle *area);
-LV_API VisVideo *visual_video_new_sub_by_values (VisVideo *src, int x, int y, int width, int height);
-LV_API VisVideo *visual_video_new_sub_with_boundary (VisRectangle *drect, VisVideo *src, VisRectangle *srect);
-LV_API VisVideo *visual_video_new_sub_all (VisVideo *src);
+LV_API LV_NODISCARD VisVideo *visual_video_new_sub (VisVideo *src, VisRectangle *area);
+LV_API LV_NODISCARD VisVideo *visual_video_new_sub_by_values (VisVideo *src, int x, int y, int width, int height);
+LV_API LV_NODISCARD VisVideo *visual_video_new_sub_with_boundary (VisRectangle *drect, VisVideo *src, VisRectangle *srect);
+LV_API LV_NODISCARD VisVideo *visual_video_new_sub_all (VisVideo *src);
 
 LV_API void visual_video_set_compose_type     (VisVideo *video, VisVideoComposeType type);
 LV_API void visual_video_set_compose_colorkey (VisVideo *video, VisColor *color);
@@ -576,11 +576,11 @@ LV_API void visual_video_scale  (VisVideo *dest, VisVideo *src, VisVideoScaleMet
 
 LV_API void visual_video_scale_depth (VisVideo *dest, VisVideo *src, VisVideoScaleMethod scale_method);
 
-LV_API VisVideo *visual_video_scale_depth_new (VisVideo*           src,
-                                               int                 width,
-                                               int                 height,
-                                               VisVideoDepth       depth,
-                                               VisVideoScaleMethod scale_method);
+LV_API LV_NODISCARD VisVideo *visual_video_scale_depth_new (VisVideo*           src,
+                                                            int                 width,
+                                                            int                 height,
+                                                            VisVideoDepth       depth,
+                                                            VisVideoScaleMethod scale_method);
 
 LV_API const char *visual_video_depth_name (VisVideoDepth depth);
 


### PR DESCRIPTION
This PR adds the define `LV_NODISCARD` for marking C API functions whose return results should not be discarded. I have added them to API functions that return allocated objects.

The define uses compiler-specific function attributes to achieve this when building C code.

For C++, `[[nodiscard]]` already exists from C++17 onwards. C++20 has a variant that accepts a string literal for explaining the rationale that could be displayed in compiler messages. I can't see how to achieve the same for C unfortunately.

Use `LV_NODISCARD` only for C API functions. `[[nodiscard]]` for C++ functions.
