### PR TITLE
[0.4.x] libvisual: Improve AltiVec detection for PPC/PPC64 Linux

### DIFF
--- a/libvisual/libvisual/lv_cpu.c
+++ b/libvisual/libvisual/lv_cpu.c
@@ -50,7 +50,18 @@
 #endif
 
 #if defined(VISUAL_OS_LINUX)
+#if defined(VISUAL_ARCH_POWERPC)
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#include <linux/auxvec.h>
+#include <asm/cputable.h>
+#else /* VISUAL_ARCH_POWERPC */
 #include <signal.h>
+#endif
 #endif
 
 #if defined(VISUAL_OS_WIN32)
@@ -154,6 +165,46 @@ static void check_os_altivec_support( void )
 	if (err == 0)
 		if (has_vu != 0)
 			__lv_cpu_caps.hasAltiVec = 1;
+#elif defined (VISUAL_OS_LINUX)
+	static int available = -1;
+	int new_avail = 0;
+	char fname[64];
+	unsigned long buf[64];
+	ssize_t count;
+	pid_t pid;
+	int fd, i;
+
+	if (available != -1)
+		return;
+
+	pid = getpid();
+	snprintf(fname, sizeof(fname)-1, "/proc/%d/auxv", pid);
+
+	fd = open(fname, O_RDONLY);
+	if (fd < 0)
+		goto out;
+more:
+	count = read(fd, buf, sizeof(buf));
+	if (count < 0)
+		goto out_close;
+
+	for (i=0; i < (count / sizeof(unsigned long)); i += 2) {
+		if (buf[i] == AT_HWCAP) {
+			new_avail = !!(buf[i+1] & PPC_FEATURE_HAS_ALTIVEC);
+			goto out_close;
+		} else if (buf[i] == AT_NULL) {
+			goto out_close;
+		}
+	}
+
+	if (count == sizeof(buf))
+		goto more;
+out_close:
+	close(fd);
+out:
+	available = new_avail;
+	if (available)
+		__lv_cpu_caps.hasAltiVec = 1;
 #else /* !VISUAL_OS_DARWIN */
 	/* no Darwin, do it the brute-force way */
 	/* this is borrowed from the libmpeg2 library */


### PR DESCRIPTION
This is from https://src.fedoraproject.org/rpms/libvisual/blob/rawhide/f/libvisual-0.4.0-better-altivec-detection.patch , started out at https://bugzilla.redhat.com/show_bug.cgi?id=435771#c21 originally.

Thanks to @dwmw2!
