### PR TITLE
Core (lv-tool): Apply 'override' and 'final' to classes.

### DIFF
--- a/libvisual/tools/lv-tool/display/display.hpp
+++ b/libvisual/tools/lv-tool/display/display.hpp
@@ -31,7 +31,8 @@
 
 class DisplayDriver;
 
-class Display {
+class Display final
+{
 public:
 
     explicit Display (std::string const& driver_name);
@@ -74,7 +75,7 @@ private:
     const std::unique_ptr<Impl> m_impl;
 };
 
-class DisplayLock
+class DisplayLock final
 {
 public:
 

--- a/libvisual/tools/lv-tool/display/display_driver_factory.hpp
+++ b/libvisual/tools/lv-tool/display/display_driver_factory.hpp
@@ -34,7 +34,7 @@ typedef std::function<DisplayDriver* (Display& display)> DisplayDriverCreator;
 
 typedef std::vector<std::string> DisplayDriverList;
 
-class DisplayDriverFactory
+class DisplayDriverFactory final
 {
 public:
 

--- a/libvisual/tools/lv-tool/display/sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/sdl_driver.cpp
@@ -55,7 +55,7 @@ namespace {
 
   void get_nearest_resolution (int& width, int& height);
 
-  class SDLDriver
+  class SDLDriver final
       : public DisplayDriver
   {
   public:
@@ -72,16 +72,16 @@ namespace {
           , m_running         (false)
       {}
 
-      virtual ~SDLDriver ()
+      ~SDLDriver () override
       {
           close ();
       }
 
-      virtual LV::VideoPtr create (VisVideoDepth depth,
-                                   VisVideoAttrOptions const* vidoptions,
-                                   unsigned int width,
-                                   unsigned int height,
-                                   bool resizable)
+      LV::VideoPtr create (VisVideoDepth depth,
+                           VisVideoAttrOptions const* vidoptions,
+                           unsigned int width,
+                           unsigned int height,
+                           bool resizable) override
       {
 
           int videoflags = 0;
@@ -151,7 +151,7 @@ namespace {
           return m_screen_video;
       }
 
-      virtual void close ()
+      void close () override
       {
           if (!m_running)
               return;
@@ -163,24 +163,24 @@ namespace {
           m_running = false;
       }
 
-      virtual void lock ()
+      void lock () override
       {
           if (SDL_MUSTLOCK (m_screen))
               SDL_LockSurface (m_screen);
       }
 
-      virtual void unlock ()
+      void unlock () override
       {
           if (SDL_MUSTLOCK (m_screen) == SDL_TRUE)
               SDL_UnlockSurface (m_screen);
       }
 
-      virtual bool is_fullscreen () const
+      bool is_fullscreen () const override
       {
           return m_screen->flags & SDL_FULLSCREEN;
       }
 
-      virtual void set_fullscreen (bool fullscreen, bool autoscale)
+      void set_fullscreen (bool fullscreen, bool autoscale) override
       {
           if (fullscreen) {
               if (!(m_screen->flags & SDL_FULLSCREEN)) {
@@ -211,17 +211,17 @@ namespace {
           }
       }
 
-      virtual LV::VideoPtr get_video () const
+      LV::VideoPtr get_video () const override
       {
           return m_screen_video;
       }
 
-      virtual void set_title(std::string const& title)
+      void set_title(std::string const& title) override
       {
           SDL_WM_SetCaption (title.c_str(), nullptr);
       }
 
-      virtual void update_rect (LV::Rect const& rect)
+      void update_rect (LV::Rect const& rect) override
       {
           if (m_screen->format->BitsPerPixel == 8) {
               auto const& pal = m_display.get_video ()->get_palette ();
@@ -246,7 +246,7 @@ namespace {
               SDL_UpdateRect (m_screen, rect.x, rect.y, rect.width, rect.height);
       }
 
-      virtual void drain_events (VisEventQueue& eventqueue)
+      void drain_events (VisEventQueue& eventqueue) override
       {
           // Visible or not
 

--- a/libvisual/tools/lv-tool/display/stdout_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_driver.cpp
@@ -36,7 +36,7 @@
 
 namespace {
 
-  class StdoutDriver
+  class StdoutDriver final
       : public DisplayDriver
   {
   public:
@@ -46,16 +46,16 @@ namespace {
           (void)display;
       }
 
-      virtual ~StdoutDriver ()
+      ~StdoutDriver () override
       {
           close ();
       }
 
-      virtual LV::VideoPtr create (VisVideoDepth depth,
-                                   VisVideoAttrOptions const* vidoptions,
-                                   unsigned int width,
-                                   unsigned int height,
-                                   bool resizable)
+      LV::VideoPtr create (VisVideoDepth depth,
+                           VisVideoAttrOptions const* vidoptions,
+                           unsigned int width,
+                           unsigned int height,
+                           bool resizable) override
       {
           (void)vidoptions;
           (void)resizable;
@@ -71,27 +71,27 @@ namespace {
           return m_screen_video;
       }
 
-      virtual void close ()
+      void close () override
       {
           m_screen_video.reset ();
       }
 
-      virtual void lock ()
+      void lock () override
       {
           // nothing to do
       }
 
-      virtual void unlock ()
+      void unlock () override
       {
           // nothing to do
       }
 
-      virtual bool is_fullscreen () const
+      bool is_fullscreen () const override
       {
           return false;
       }
 
-      virtual void set_fullscreen (bool fullscreen, bool autoscale)
+      void set_fullscreen (bool fullscreen, bool autoscale) override
       {
           (void)fullscreen;
           (void)autoscale;
@@ -99,19 +99,19 @@ namespace {
           // nothing to do
       }
 
-      virtual LV::VideoPtr get_video () const
+      LV::VideoPtr get_video () const override
       {
           return m_screen_video;
       }
 
-      virtual void set_title(std::string const& title)
+      void set_title(std::string const& title) override
       {
           (void)title;
 
           // nothing to do
       }
 
-      virtual void update_rect (LV::Rect const& rect)
+      void update_rect (LV::Rect const& rect) override
       {
           (void)rect;
 
@@ -119,7 +119,7 @@ namespace {
               visual_log (VISUAL_LOG_ERROR, "Failed to write pixels to stdout");
       }
 
-      virtual void drain_events (VisEventQueue& eventqueue)
+      void drain_events (VisEventQueue& eventqueue) override
       {
           (void)eventqueue;
 

--- a/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
@@ -66,7 +66,7 @@ namespace {
 
   void get_nearest_resolution (int& width, int& height);
 
-  class StdoutSDLDriver
+  class StdoutSDLDriver final
       : public DisplayDriver
   {
   public:
@@ -83,16 +83,16 @@ namespace {
           , m_running         (false)
       {}
 
-      virtual ~StdoutSDLDriver ()
+      ~StdoutSDLDriver () override
       {
           close ();
       }
 
-      virtual LV::VideoPtr create (VisVideoDepth depth,
-                                   VisVideoAttrOptions const* vidoptions,
-                                   unsigned int width,
-                                   unsigned int height,
-                                   bool resizable)
+      LV::VideoPtr create (VisVideoDepth depth,
+                           VisVideoAttrOptions const* vidoptions,
+                           unsigned int width,
+                           unsigned int height,
+                           bool resizable) override
       {
 
           int videoflags = 0;
@@ -170,7 +170,7 @@ namespace {
           return m_screen_video;
       }
 
-      virtual void close ()
+      void close () override
       {
           if (!m_running)
               return;
@@ -180,24 +180,24 @@ namespace {
           m_running = false;
       }
 
-      virtual void lock ()
+      void lock () override
       {
           if (SDL_MUSTLOCK (m_screen))
               SDL_LockSurface (m_screen);
       }
 
-      virtual void unlock ()
+      void unlock () override
       {
           if (SDL_MUSTLOCK (m_screen) == SDL_TRUE)
               SDL_UnlockSurface (m_screen);
       }
 
-      virtual bool is_fullscreen () const
+      bool is_fullscreen () const override
       {
           return m_screen->flags & SDL_FULLSCREEN;
       }
 
-      virtual void set_fullscreen (bool fullscreen, bool autoscale)
+      void set_fullscreen (bool fullscreen, bool autoscale) override
       {
           if (fullscreen) {
               if (!(m_screen->flags & SDL_FULLSCREEN)) {
@@ -228,17 +228,17 @@ namespace {
           }
       }
 
-      virtual LV::VideoPtr get_video () const
+      LV::VideoPtr get_video () const override
       {
           return m_screen_video;
       }
 
-      virtual void set_title(std::string const& title)
+      void set_title(std::string const& title) override
       {
           SDL_WM_SetCaption (title.c_str(), nullptr);
       }
 
-      virtual void update_rect (LV::Rect const& rect)
+      void update_rect (LV::Rect const& rect) override
       {
           if (m_screen->format->BitsPerPixel == 8) {
               auto const& pal = m_display.get_video ()->get_palette ();
@@ -291,7 +291,7 @@ namespace {
           }
       }
 
-      virtual void drain_events (VisEventQueue& eventqueue)
+      void drain_events (VisEventQueue& eventqueue) override
       {
           // Visible or not
 

--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -90,7 +90,7 @@ namespace {
   };
 
   /** Class to manage LV's lifecycle */
-  class Libvisual
+  class Libvisual final
   {
   public:
 


### PR DESCRIPTION
- Use `final` to prohibit subclassing where needed
- Use `override` instead of `virtual` when overriding virtual methods or implementing pure virtual methods.
