### PR TITLE
Core (lv-tool): Protect new display driver instances using unique_ptr

### DIFF
--- a/libvisual/tools/lv-tool/display/display.cpp
+++ b/libvisual/tools/lv-tool/display/display.cpp
@@ -25,6 +25,7 @@
 #include "display.hpp"
 #include "display_driver_factory.hpp"
 #include <libvisual/libvisual.h>
+#include <utility>
 #include <stdexcept>
 #include <string>
 
@@ -34,8 +35,8 @@ public:
 
     std::unique_ptr<DisplayDriver> driver;
 
-    Impl ()
-        : driver (nullptr)
+    Impl (std::unique_ptr<DisplayDriver> driver_)
+        : driver {std::move (driver_)}
     {}
 
     ~Impl ()
@@ -43,10 +44,8 @@ public:
 };
 
 Display::Display (std::string const& driver_name)
-  : m_impl (new Impl)
+    : m_impl {new Impl {DisplayDriverFactory::instance().make (driver_name, *this)}}
 {
-    m_impl->driver.reset (DisplayDriverFactory::instance().make (driver_name, *this));
-
     if (!m_impl->driver) {
         throw std::runtime_error ("Failed to load display driver '" + driver_name + "'. Valid driver set? (\"--driver\" parameter)");
     }

--- a/libvisual/tools/lv-tool/display/display_driver_factory.cpp
+++ b/libvisual/tools/lv-tool/display/display_driver_factory.cpp
@@ -62,7 +62,7 @@ void DisplayDriverFactory::add_driver (std::string const& name, Creator const& c
     m_impl->creators[name] = creator;
 }
 
-DisplayDriver* DisplayDriverFactory::make (std::string const& name, Display& display)
+std::unique_ptr<DisplayDriver> DisplayDriverFactory::make (std::string const& name, Display& display)
 {
     auto entry = m_impl->creators.find (name);
 
@@ -70,7 +70,7 @@ DisplayDriver* DisplayDriverFactory::make (std::string const& name, Display& dis
         return nullptr;
     }
 
-    return entry->second (display);
+    return std::unique_ptr<DisplayDriver> {entry->second (display)};
 }
 
 bool DisplayDriverFactory::has_driver (std::string const& name) const

--- a/libvisual/tools/lv-tool/display/display_driver_factory.hpp
+++ b/libvisual/tools/lv-tool/display/display_driver_factory.hpp
@@ -46,7 +46,7 @@ public:
 	    return m_instance;
     }
 
-    DisplayDriver* make (std::string const& name, Display& display);
+    std::unique_ptr<DisplayDriver> make (std::string const& name, Display& display);
 
     void add_driver (std::string const& name, Creator const& creator);
 


### PR DESCRIPTION
`DisplayDriverFactory::make()` currently returns driver instances in raw pointers. This patch changes it to wrap them in `std::unique_ptr`.

Note that the various constructors `stdout_driver_new()`, `stdout_sdl_driver_new()`, etc. still return raw pointers. The driver code are meant to be externalised into loadable SOs and I'm unsure if we can return `std::unique_ptr` from there.

