### PR TITLE
Core: Optimize string arguments and returns

### DIFF
--- a/libvisual/libvisual/lv_actor.cpp
+++ b/libvisual/libvisual/lv_actor.cpp
@@ -25,6 +25,7 @@
 #include "lv_common.h"
 #include "lv_plugin_registry.h"
 #include <stdexcept>
+#include <string>
 
 namespace LV {
 

--- a/libvisual/libvisual/lv_actor.cpp
+++ b/libvisual/libvisual/lv_actor.cpp
@@ -74,14 +74,14 @@ namespace LV {
       return actor_plugin ? actor_plugin->vidoptions.depth : VISUAL_VIDEO_DEPTH_NONE;
   }
 
-  bool Actor::available(std::string const& name) {
+  bool Actor::available(std::string_view name) {
       return LV::PluginRegistry::instance()->has_plugin (VISUAL_PLUGIN_TYPE_ACTOR, name);
   }
 
-  ActorPtr Actor::load (std::string const& name)
+  ActorPtr Actor::load (std::string_view name)
   {
       try {
-          return {new Actor (name), false};
+          return {new Actor {name}, false};
       }
       catch (std::exception& error) {
           visual_log (VISUAL_LOG_ERROR, "%s", error.what ());
@@ -89,7 +89,7 @@ namespace LV {
       }
   }
 
-  Actor::Actor (std::string const& name)
+  Actor::Actor (std::string_view name)
       : m_impl      {new Impl}
       , m_ref_count {1}
   {
@@ -97,7 +97,7 @@ namespace LV {
           throw std::runtime_error {"Actor plugin not found"};
       }
 
-      m_impl->plugin = visual_plugin_load (VISUAL_PLUGIN_TYPE_ACTOR, name.c_str ());
+      m_impl->plugin = visual_plugin_load (VISUAL_PLUGIN_TYPE_ACTOR, std::string {name}.c_str ());
       if (!m_impl->plugin) {
           throw std::runtime_error {"Failed to load actor plugin"};
       }

--- a/libvisual/libvisual/lv_actor.h
+++ b/libvisual/libvisual/lv_actor.h
@@ -37,8 +37,8 @@
 #ifdef __cplusplus
 
 #include <libvisual/lv_intrusive_ptr.hpp>
-#include <string>
 #include <memory>
+#include <string_view>
 
 namespace LV
 {
@@ -59,7 +59,7 @@ namespace LV
        *
        * @return True if an actor plugin by that name is available, else false
        */
-      static bool available (std::string const& name);
+      static bool available (std::string_view name);
 
       /**
        * Creates a new Actor with a plugin of a given name.
@@ -70,7 +70,7 @@ namespace LV
        *
        * @return New actor, or nullptr if plugin failed to load
        */
-      static ActorPtr load (std::string const& name);
+      static ActorPtr load (std::string_view name);
 
       Actor (Actor const&) = delete;
 
@@ -165,7 +165,7 @@ namespace LV
 
       mutable unsigned int m_ref_count;
 
-      explicit Actor (std::string const& name);
+      explicit Actor (std::string_view name);
   };
 
   inline void intrusive_ptr_add_ref (Actor const* actor)

--- a/libvisual/libvisual/lv_audio.cpp
+++ b/libvisual/libvisual/lv_audio.cpp
@@ -44,13 +44,13 @@ namespace LV {
   {
   public:
 
-      typedef std::unordered_map<std::string, AudioChannelPtr> ChannelList;
+      using ChannelList = std::unordered_map<std::string, AudioChannelPtr>;
 
       ChannelList channels;
 
-      void upload_to_channel (std::string const& name, BufferConstPtr const& samples, Time const& timestamp);
+      void upload_to_channel (std::string_view name, BufferConstPtr const& samples, Time const& timestamp);
 
-      AudioChannel* get_channel (std::string const& name) const;
+      AudioChannel* get_channel (std::string_view name) const;
   };
 
   class AudioChannel
@@ -60,7 +60,7 @@ namespace LV {
       std::string name;
       AudioStream stream;
 
-      explicit AudioChannel (std::string const& name);
+      explicit AudioChannel (std::string_view name);
 
       ~AudioChannel ();
 
@@ -88,22 +88,26 @@ namespace LV {
 
   } // anonymous
 
-  void Audio::Impl::upload_to_channel (std::string const& name, BufferConstPtr const& samples, Time const& timestamp)
+  void Audio::Impl::upload_to_channel (std::string_view name, BufferConstPtr const& samples, Time const& timestamp)
   {
+      std::string name_str {name};
+
       if (!get_channel (name)) {
-          channels[name] = std::make_unique<AudioChannel> (name);
+          channels[name_str] = std::make_unique<AudioChannel> (name);
       }
 
-      channels[name]->add_samples (samples, timestamp);
+      channels[name_str]->add_samples (samples, timestamp);
   }
 
-  AudioChannel* Audio::Impl::get_channel (std::string const& name) const
+  AudioChannel* Audio::Impl::get_channel (std::string_view name) const
   {
-      auto entry = channels.find (name);
+      std::string name_str {name};
+
+      auto entry = channels.find (name_str);
       return entry != channels.end () ? entry->second.get () : nullptr;
   }
 
-  AudioChannel::AudioChannel (std::string const& name_)
+  AudioChannel::AudioChannel (std::string_view name_)
       : name (name_)
   {}
 
@@ -140,7 +144,7 @@ namespace LV {
       return *this;
   }
 
-  bool Audio::get_sample (BufferPtr const& buffer, std::string const& channel_name)
+  bool Audio::get_sample (BufferPtr const& buffer, std::string_view channel_name)
   {
       auto channel = m_impl->get_channel (channel_name);
 
@@ -220,7 +224,7 @@ namespace LV {
       }
   }
 
-  void Audio::get_spectrum (BufferPtr const& buffer, std::size_t samplelen, std::string const& channel_name, bool normalised)
+  void Audio::get_spectrum (BufferPtr const& buffer, std::size_t samplelen, std::string_view channel_name, bool normalised)
   {
       auto sample = Buffer::create (samplelen);
 
@@ -230,7 +234,7 @@ namespace LV {
           buffer->fill (0);
   }
 
-  void Audio::get_spectrum (BufferPtr const& buffer, std::size_t samplelen, std::string const& channel_name, bool normalised, float multiplier)
+  void Audio::get_spectrum (BufferPtr const& buffer, std::size_t samplelen, std::string_view channel_name, bool normalised, float multiplier)
   {
       auto spectrum {Buffer::create (buffer->get_size ())};
       get_spectrum (spectrum, samplelen, channel_name, normalised);
@@ -314,7 +318,7 @@ namespace LV {
   void Audio::input (BufferPtr const&         buffer,
                      VisAudioSampleRateType   rate,
                      VisAudioSampleFormatType format,
-                     std::string const&       channel_name)
+                     std::string_view         channel_name)
   {
       (void)rate;
 

--- a/libvisual/libvisual/lv_audio.h
+++ b/libvisual/libvisual/lv_audio.h
@@ -66,7 +66,7 @@ typedef enum {
 #ifdef __cplusplus
 
 #include <memory>
-#include <string>
+#include <string_view>
 #include <cstdarg>
 
 namespace LV {
@@ -114,7 +114,7 @@ namespace LV {
        *
        * @return true if successful, false if channel does not exist
        */
-      bool get_sample (BufferPtr const& buffer, std::string const& channel_name);
+      bool get_sample (BufferPtr const& buffer, std::string_view channel_name);
 
       /**
        * Returns samples downmixed by averaging a set of channels.
@@ -153,9 +153,9 @@ namespace LV {
        * @param channel_name name of channel
        * @param normalised   normalise ampltitudes to [0.0, 1.0]
        */
-      void get_spectrum (BufferPtr const& buffer, std::size_t sample_count, std::string const& channel_name, bool normalised);
+      void get_spectrum (BufferPtr const& buffer, std::size_t sample_count, std::string_view channel_name, bool normalised);
 
-      void get_spectrum (BufferPtr const& buffer, std::size_t sample_count, std::string const& channel_name, bool normalised, float multiplier);
+      void get_spectrum (BufferPtr const& buffer, std::size_t sample_count, std::string_view channel_name, bool normalised, float multiplier);
 
       /**
        * Returns the amplitude spectrum of a set of samples.
@@ -196,7 +196,7 @@ namespace LV {
       void input (BufferPtr const& buffer,
                   VisAudioSampleRateType rate,
                   VisAudioSampleFormatType format,
-                  std::string const& channel_name);
+                  std::string_view channel_name);
 
   private:
 

--- a/libvisual/libvisual/lv_bin.cpp
+++ b/libvisual/libvisual/lv_bin.cpp
@@ -151,7 +151,7 @@ namespace LV {
       return m_impl->input;
   }
 
-  void Bin::set_morph (std::string const& morph_name)
+  void Bin::set_morph (std::string_view morph_name)
   {
       m_impl->morph = Morph::load (morph_name);
       visual_return_if_fail (m_impl->morph);
@@ -190,7 +190,7 @@ namespace LV {
       return true;
   }
 
-  bool Bin::connect (std::string const& actor_name, std::string const& input_name)
+  bool Bin::connect (std::string_view actor_name, std::string_view input_name)
   {
       // Create the actor
       auto actor = Actor::load (actor_name);
@@ -362,10 +362,13 @@ namespace LV {
           return *m_impl->actor->get_palette ();
   }
 
-  void Bin::switch_actor (std::string const& actor_name)
+  void Bin::switch_actor (std::string_view actor_name)
   {
+      // FIXME: This is needed because visual_log() takes only null-terminated C strings.
+      std::string actor_name_str {actor_name};
+
       visual_log (VISUAL_LOG_DEBUG, "switching to a new actor: %s, old actor: %s",
-				  actor_name.c_str (), visual_plugin_get_info (m_impl->actor->get_plugin ())->plugname);
+				  actor_name_str.c_str (), visual_plugin_get_info (m_impl->actor->get_plugin ())->plugname);
 
       if (m_impl->actmorph) {
           m_impl->actmorph.reset ();

--- a/libvisual/libvisual/lv_bin.cpp
+++ b/libvisual/libvisual/lv_bin.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "lv_bin.h"
 #include "lv_common.h"
+#include <string>
 
 namespace LV {
 

--- a/libvisual/libvisual/lv_bin.h
+++ b/libvisual/libvisual/lv_bin.h
@@ -43,7 +43,7 @@ typedef enum {
 #ifdef __cplusplus
 
 #include <memory>
-#include <string>
+#include <string_view>
 
 namespace LV {
 
@@ -65,9 +65,9 @@ namespace LV {
 	  InputPtr const& get_input () const;
 	  MorphPtr const& get_morph () const;
 
-	  void set_morph (std::string const& morph_name);
+	  void set_morph (std::string_view morph_name);
 
-	  bool connect (std::string const& actor_name, std::string const& input_name);
+	  bool connect (std::string_view actor_name, std::string_view input_name);
 
 	  void sync (bool noevent);
 
@@ -87,7 +87,7 @@ namespace LV {
 
 	  Palette const& get_palette () const;
 
-	  void switch_actor (std::string const& actname);
+	  void switch_actor (std::string_view actname);
 
 	  void switch_finalize ();
 

--- a/libvisual/libvisual/lv_input.cpp
+++ b/libvisual/libvisual/lv_input.cpp
@@ -26,6 +26,7 @@
 #include "lv_common.h"
 #include "lv_plugin_registry.h"
 #include <stdexcept>
+#include <string>
 
 namespace LV {
 

--- a/libvisual/libvisual/lv_input.cpp
+++ b/libvisual/libvisual/lv_input.cpp
@@ -60,11 +60,11 @@ namespace LV {
       return static_cast<VisInputPlugin*> (visual_plugin_get_info (plugin)->plugin);
   }
 
-  bool Input::available(std::string const& name) {
+  bool Input::available(std::string_view name) {
       return LV::PluginRegistry::instance()->has_plugin (VISUAL_PLUGIN_TYPE_INPUT, name);
   }
 
-  InputPtr Input::load (std::string const& name)
+  InputPtr Input::load (std::string_view name)
   {
       try {
           return {new Input{name}, false};
@@ -75,7 +75,7 @@ namespace LV {
       }
   }
 
-  Input::Input (std::string const& name)
+  Input::Input (std::string_view name)
       : m_impl      {new Impl}
       , m_ref_count {1}
   {
@@ -83,7 +83,7 @@ namespace LV {
           throw std::runtime_error {"Input plugin not found"};
       }
 
-      m_impl->plugin = visual_plugin_load (VISUAL_PLUGIN_TYPE_INPUT, name.c_str ());
+      m_impl->plugin = visual_plugin_load (VISUAL_PLUGIN_TYPE_INPUT, std::string {name}.c_str ());
       if (!m_impl->plugin) {
           throw std::runtime_error {"Failed to load input plugin"};
       }

--- a/libvisual/libvisual/lv_input.h
+++ b/libvisual/libvisual/lv_input.h
@@ -37,6 +37,7 @@
 #include <libvisual/lv_intrusive_ptr.hpp>
 #include <functional>
 #include <memory>
+#include <string_view>
 
 namespace LV {
 
@@ -55,7 +56,7 @@ namespace LV {
        *
        * @return True if an input plugin by that name is available, else false
        */
-      static bool available (std::string const& name);
+      static bool available (std::string_view name);
 
       /**
        * Creates a new Input with a plugin of a given name.
@@ -64,7 +65,7 @@ namespace LV {
        *
        * @return A new Input, or nullptr on failure.
        */
-      static InputPtr load (std::string const& name);
+      static InputPtr load (std::string_view name);
 
       ~Input ();
 
@@ -116,7 +117,7 @@ namespace LV {
 
       mutable unsigned int m_ref_count;
 
-      explicit Input (std::string const& name);
+      explicit Input (std::string_view name);
   };
 
   inline void intrusive_ptr_add_ref (Input const* input)

--- a/libvisual/libvisual/lv_libvisual.cpp
+++ b/libvisual/libvisual/lv_libvisual.cpp
@@ -37,6 +37,8 @@
 
 #include "gettext.h"
 
+#include <string>
+
 extern "C" {
   void visual_cpu_initialize (void);
   void visual_mem_initialize (void);
@@ -107,9 +109,10 @@ namespace LV
       m_instance.reset (new System {argc, argv});
   }
 
-  std::string_view System::get_version () const
+  std::string const& System::get_version () const
   {
-      return VISUAL_VERSION " (" LV_REVISION ")";
+      static std::string const version_str {VISUAL_VERSION " (" LV_REVISION ")"};
+      return version_str;
   }
 
   int System::get_api_version () const
@@ -138,7 +141,7 @@ namespace LV
       (void)argc;
       (void)argv;
 
-      visual_log (VISUAL_LOG_INFO, "Starting Libvisual %s", std::string {get_version ()}.c_str ());
+      visual_log (VISUAL_LOG_INFO, "Starting Libvisual %s", get_version ().c_str ());
 
 #if ENABLE_NLS
       bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);

--- a/libvisual/libvisual/lv_libvisual.cpp
+++ b/libvisual/libvisual/lv_libvisual.cpp
@@ -107,7 +107,7 @@ namespace LV
       m_instance.reset (new System {argc, argv});
   }
 
-  std::string System::get_version () const
+  std::string_view System::get_version () const
   {
       return VISUAL_VERSION " (" LV_REVISION ")";
   }
@@ -138,7 +138,7 @@ namespace LV
       (void)argc;
       (void)argv;
 
-      visual_log (VISUAL_LOG_INFO, "Starting Libvisual %s", get_version ().c_str ());
+      visual_log (VISUAL_LOG_INFO, "Starting Libvisual %s", std::string {get_version ()}.c_str ());
 
 #if ENABLE_NLS
       bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);

--- a/libvisual/libvisual/lv_libvisual.h
+++ b/libvisual/libvisual/lv_libvisual.h
@@ -63,7 +63,7 @@ namespace LV {
        *
        * @return version string
        */
-      std::string get_version () const;
+      std::string_view get_version () const;
 
       /**
        * Returns the Libvisual API verison.

--- a/libvisual/libvisual/lv_libvisual.h
+++ b/libvisual/libvisual/lv_libvisual.h
@@ -63,7 +63,7 @@ namespace LV {
        *
        * @return version string
        */
-      std::string_view get_version () const;
+      std::string const& get_version () const;
 
       /**
        * Returns the Libvisual API verison.

--- a/libvisual/libvisual/lv_libvisual_c.cpp
+++ b/libvisual/libvisual/lv_libvisual_c.cpp
@@ -6,8 +6,7 @@ extern "C" {
 
   const char *visual_get_version ()
   {
-      static std::string version {LV::System::instance ()->get_version ()};
-      return version.c_str ();
+      return LV::System::instance ()->get_version ().c_str ();
   }
 
   int visual_get_api_version ()

--- a/libvisual/libvisual/lv_libvisual_c.cpp
+++ b/libvisual/libvisual/lv_libvisual_c.cpp
@@ -6,7 +6,7 @@ extern "C" {
 
   const char *visual_get_version ()
   {
-      static std::string version = LV::System::instance()->get_version ();
+      static std::string version {LV::System::instance ()->get_version ()};
       return version.c_str ();
   }
 

--- a/libvisual/libvisual/lv_morph.cpp
+++ b/libvisual/libvisual/lv_morph.cpp
@@ -26,6 +26,7 @@
 #include "lv_plugin_registry.h"
 #include <algorithm>
 #include <stdexcept>
+#include <string>
 
 namespace LV {
 

--- a/libvisual/libvisual/lv_morph.cpp
+++ b/libvisual/libvisual/lv_morph.cpp
@@ -74,11 +74,11 @@ namespace LV {
       return m_impl->plugin;
   }
 
-  bool Morph::available(std::string const& name) {
+  bool Morph::available(std::string_view name) {
       return LV::PluginRegistry::instance()->has_plugin (VISUAL_PLUGIN_TYPE_MORPH, name);
   }
 
-  MorphPtr Morph::load (std::string const& name)
+  MorphPtr Morph::load (std::string_view name)
   {
       try {
           return {new Morph {name}, false};
@@ -90,7 +90,7 @@ namespace LV {
       }
   }
 
-  Morph::Morph (std::string const& name)
+  Morph::Morph (std::string_view name)
       : m_impl      (new Impl)
       , m_ref_count (1)
   {
@@ -98,7 +98,7 @@ namespace LV {
           throw std::runtime_error {"Morph plugin not found"};
       }
 
-      m_impl->plugin = visual_plugin_load (VISUAL_PLUGIN_TYPE_MORPH, name.c_str ());
+      m_impl->plugin = visual_plugin_load (VISUAL_PLUGIN_TYPE_MORPH, std::string {name}.c_str ());
       if (!m_impl->plugin) {
           throw std::runtime_error {"Failed to load morph plugin"};
       }

--- a/libvisual/libvisual/lv_morph.h
+++ b/libvisual/libvisual/lv_morph.h
@@ -37,8 +37,8 @@
 #ifdef __cplusplus
 
 #include <libvisual/lv_intrusive_ptr.hpp>
-#include <string>
 #include <memory>
+#include <string_view>
 
 namespace LV {
 
@@ -58,7 +58,7 @@ namespace LV {
        *
        * @return True if a morph plugin by that name is available, else false
        */
-      static bool available (std::string const& name);
+      static bool available (std::string_view name);
 
       /**
        * Creates a new Morph wit a plugin of a given name.
@@ -69,7 +69,7 @@ namespace LV {
        *
        * @return New morph, or nullptr if plugin failed to load
        */
-      static MorphPtr load (std::string const& name);
+      static MorphPtr load (std::string_view name);
 
       Morph (Morph const& morph) = delete;
 
@@ -162,7 +162,7 @@ private:
 
       mutable unsigned int m_ref_count;
 
-      explicit Morph (std::string const& name);
+      explicit Morph (std::string_view name);
   };
 
   inline void intrusive_ptr_add_ref (Morph const* morph)

--- a/libvisual/libvisual/lv_param.cpp
+++ b/libvisual/libvisual/lv_param.cpp
@@ -90,7 +90,7 @@ namespace LV
   {
   public:
 
-      typedef std::map<std::string, std::unique_ptr<Param>> Entries;
+      using Entries = std::map<std::string, std::unique_ptr<Param>, std::less<>>;
 
       Entries     entries;
       EventQueue* event_queue;
@@ -188,7 +188,7 @@ namespace LV
       m_impl->entries.emplace (param->name, std::unique_ptr<Param> {param});
   }
 
-  bool ParamList::remove (std::string const& name)
+  bool ParamList::remove (std::string_view name)
   {
       auto entry = m_impl->entries.find (name);
       if (entry != m_impl->entries.end ()) {
@@ -199,7 +199,7 @@ namespace LV
       return false;
   }
 
-  Param* ParamList::get (std::string const& name) const
+  Param* ParamList::get (std::string_view name) const
   {
       auto entry = m_impl->entries.find (name);
       if (entry != m_impl->entries.end ()) {

--- a/libvisual/libvisual/lv_param.cpp
+++ b/libvisual/libvisual/lv_param.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <list>
 #include <stdexcept>
+#include <string>
 #include <cstdarg>
 
 namespace LV

--- a/libvisual/libvisual/lv_param.h
+++ b/libvisual/libvisual/lv_param.h
@@ -39,6 +39,7 @@
 
 #include <initializer_list>
 #include <memory>
+#include <string_view>
 
 namespace LV {
 
@@ -102,7 +103,7 @@ namespace LV {
        *
        * @return true on success, false otherwise
        */
-      bool remove (std::string const& name);
+      bool remove (std::string_view name);
 
       /**
        * Returns a parameter by name
@@ -112,7 +113,7 @@ namespace LV {
        * @return Parameter of the given name, or nullptr if no such
        *         parameter exists
        */
-      Param* get (std::string const& name) const;
+      Param* get (std::string_view name) const;
 
       /**
        * Sets the event queue.

--- a/libvisual/libvisual/lv_plugin_registry.cpp
+++ b/libvisual/libvisual/lv_plugin_registry.cpp
@@ -135,7 +135,7 @@ namespace LV {
       }
   }
 
-  PluginRef const* PluginRegistry::find_plugin (PluginType type, std::string const& name) const
+  PluginRef const* PluginRegistry::find_plugin (PluginType type, std::string_view name) const
   {
       for (auto const& plugin : get_plugins_by_type (type)) {
           if (name == plugin.info->plugname) {
@@ -146,7 +146,7 @@ namespace LV {
       return nullptr;
   }
 
-  bool PluginRegistry::has_plugin (PluginType type, std::string const& name) const
+  bool PluginRegistry::has_plugin (PluginType type, std::string_view name) const
   {
       return find_plugin (type, name) != nullptr;
   }
@@ -162,7 +162,7 @@ namespace LV {
       return match->second;
   }
 
-  VisPluginInfo const* PluginRegistry::get_plugin_info (PluginType type, std::string const& name) const
+  VisPluginInfo const* PluginRegistry::get_plugin_info (PluginType type, std::string_view name) const
   {
       auto ref = find_plugin (type, name);
 

--- a/libvisual/libvisual/lv_plugin_registry.h
+++ b/libvisual/libvisual/lv_plugin_registry.h
@@ -8,7 +8,7 @@
 
 #include <libvisual/lv_singleton.hpp>
 #include <libvisual/lv_plugin.h>
-#include <string>
+#include <string_view>
 #include <memory>
 
 namespace LV {
@@ -39,7 +39,7 @@ namespace LV {
        */
       void add_path (std::string const& path);
 
-      PluginRef const* find_plugin (PluginType type, std::string const& name) const;
+      PluginRef const* find_plugin (PluginType type, std::string_view name) const;
 
       /**
        * Checks if a plugin is available.
@@ -49,7 +49,7 @@ namespace LV {
        *
        * @return Returns true if plugin is available, false otherwise
        */
-      bool has_plugin (PluginType type, std::string const& name) const;
+      bool has_plugin (PluginType type, std::string_view name) const;
 
       /**
        * Returns the list of all available plugins.
@@ -75,7 +75,7 @@ namespace LV {
        *
        * @return Plugin information
        */
-      VisPluginInfo const* get_plugin_info (PluginType type, std::string const& name) const;
+      VisPluginInfo const* get_plugin_info (PluginType type, std::string_view name) const;
 
   private:
 

--- a/libvisual/libvisual/lv_plugin_registry.h
+++ b/libvisual/libvisual/lv_plugin_registry.h
@@ -8,6 +8,7 @@
 
 #include <libvisual/lv_singleton.hpp>
 #include <libvisual/lv_plugin.h>
+#include <string>
 #include <string_view>
 #include <memory>
 

--- a/libvisual/libvisual/lv_songinfo.cpp
+++ b/libvisual/libvisual/lv_songinfo.cpp
@@ -74,7 +74,7 @@ namespace LV {
       m_song_name = name;
   }
 
-  std::string_view SongInfo::get_simple_name () const
+  std::string const& SongInfo::get_simple_name () const
   {
       return m_song_name;
   }
@@ -84,7 +84,7 @@ namespace LV {
       m_artist = artist;
   }
 
-  std::string SongInfo::get_artist () const
+  std::string const& SongInfo::get_artist () const
   {
       return m_artist;
   }
@@ -94,7 +94,7 @@ namespace LV {
       m_album = album;
   }
 
-  std::string SongInfo::get_album () const
+  std::string const& SongInfo::get_album () const
   {
       return m_album;
   }
@@ -104,7 +104,7 @@ namespace LV {
       m_song = song;
   }
 
-  std::string SongInfo::get_song () const
+  std::string const& SongInfo::get_song () const
   {
       return m_song;
   }

--- a/libvisual/libvisual/lv_songinfo.cpp
+++ b/libvisual/libvisual/lv_songinfo.cpp
@@ -69,17 +69,17 @@ namespace LV {
       return m_elapsed;
   }
 
-  void SongInfo::set_simple_name (std::string const& name)
+  void SongInfo::set_simple_name (std::string_view name)
   {
       m_song_name = name;
   }
 
-  std::string SongInfo::get_simple_name () const
+  std::string_view SongInfo::get_simple_name () const
   {
       return m_song_name;
   }
 
-  void SongInfo::set_artist (std::string const& artist)
+  void SongInfo::set_artist (std::string_view artist)
   {
       m_artist = artist;
   }
@@ -89,7 +89,7 @@ namespace LV {
       return m_artist;
   }
 
-  void SongInfo::set_album (std::string const& album)
+  void SongInfo::set_album (std::string_view album)
   {
       m_album = album;
   }
@@ -99,7 +99,7 @@ namespace LV {
       return m_album;
   }
 
-  void SongInfo::set_song (std::string const& song)
+  void SongInfo::set_song (std::string_view song)
   {
       m_song = song;
   }

--- a/libvisual/libvisual/lv_songinfo.h
+++ b/libvisual/libvisual/lv_songinfo.h
@@ -48,7 +48,7 @@ typedef enum {
 
 #ifdef __cplusplus
 
-#include <string>
+#include <string_view>
 
 namespace LV {
 
@@ -95,14 +95,14 @@ namespace LV {
        *
        * @param name The simple song name.
        */
-      void set_simple_name (std::string const& name);
+      void set_simple_name (std::string_view name);
 
       /**
        * Returns the simple song name.
        *
        * @return name
        */
-      std::string get_simple_name () const;
+      std::string_view get_simple_name () const;
 
       /**
        * Sets the length of a song.
@@ -138,7 +138,7 @@ namespace LV {
        *
        * @param artist artist name to set
        */
-      void set_artist (std::string const& artist);
+      void set_artist (std::string_view artist);
 
       std::string get_artist () const;
 
@@ -149,7 +149,7 @@ namespace LV {
        *
        * @param album album name to set
        */
-      void set_album (std::string const& album);
+      void set_album (std::string_view album);
 
       std::string get_album () const;
 
@@ -160,7 +160,7 @@ namespace LV {
        *
        * @param name song name to set
        */
-      void set_song (std::string const& name);
+      void set_song (std::string_view name);
 
       std::string get_song () const;
 

--- a/libvisual/libvisual/lv_songinfo.h
+++ b/libvisual/libvisual/lv_songinfo.h
@@ -48,6 +48,7 @@ typedef enum {
 
 #ifdef __cplusplus
 
+#include <string>
 #include <string_view>
 
 namespace LV {
@@ -102,7 +103,7 @@ namespace LV {
        *
        * @return name
        */
-      std::string_view get_simple_name () const;
+      std::string const& get_simple_name () const;
 
       /**
        * Sets the length of a song.
@@ -140,7 +141,7 @@ namespace LV {
        */
       void set_artist (std::string_view artist);
 
-      std::string get_artist () const;
+      std::string const& get_artist () const;
 
       /**
        * Sets the album name.
@@ -151,7 +152,7 @@ namespace LV {
        */
       void set_album (std::string_view album);
 
-      std::string get_album () const;
+      std::string const& get_album () const;
 
       /**
        * Sets the song name.
@@ -162,7 +163,7 @@ namespace LV {
        */
       void set_song (std::string_view name);
 
-      std::string get_song () const;
+      std::string const& get_song () const;
 
       /**
        * Sets the cover art.

--- a/libvisual/libvisual/lv_songinfo_c.cpp
+++ b/libvisual/libvisual/lv_songinfo_c.cpp
@@ -94,7 +94,7 @@ extern "C" {
   {
       visual_return_val_if_fail (self != nullptr, nullptr);
 
-      return LV::string_to_c (std::string {self->get_simple_name ()});
+      return LV::string_to_c (self->get_simple_name ());
   }
 
   void visual_songinfo_set_artist (VisSongInfo *self, const char *artist)

--- a/libvisual/libvisual/lv_songinfo_c.cpp
+++ b/libvisual/libvisual/lv_songinfo_c.cpp
@@ -94,7 +94,7 @@ extern "C" {
   {
       visual_return_val_if_fail (self != nullptr, nullptr);
 
-      return LV::string_to_c (self->get_simple_name ());
+      return LV::string_to_c (std::string {self->get_simple_name ()});
   }
 
   void visual_songinfo_set_artist (VisSongInfo *self, const char *artist)

--- a/libvisual/libvisual/private/lv_string_hash.hpp
+++ b/libvisual/libvisual/private/lv_string_hash.hpp
@@ -1,0 +1,34 @@
+#ifndef _LV_STRING_HASH_HPP
+#define _LV_STRING_HASH_HPP
+
+#include <string>
+#include <string_view>
+
+namespace LV {
+
+  // Transparent string hash functor.
+  struct StringHash
+  {
+      using is_transparent = void;
+
+      using HashType = std::hash<std::string_view>;
+
+      std::size_t operator() (char const* str) const
+      {
+          return HashType {} (str);
+      }
+
+      std::size_t operator() (std::string_view str) const
+      {
+          return HashType {} (str);
+      }
+
+      std::size_t operator() (std::string const& str) const
+      {
+          return HashType {} (str);
+      }
+  };
+
+} // LV namespace
+
+#endif // defined(_LV_STRING_HASH_HPP)

--- a/libvisual/tools/benchmarks/actor_bench.cpp
+++ b/libvisual/tools/benchmarks/actor_bench.cpp
@@ -3,7 +3,11 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <cstdlib>
+
+using namespace std::string_literals;
 
 namespace {
 
@@ -12,7 +16,7 @@ namespace {
   {
   public:
 
-      ActorBench (std::string const& actor_name, unsigned int width, unsigned height, VisVideoDepth depth, bool forced_depth)
+      ActorBench (std::string_view actor_name, unsigned int width, unsigned height, VisVideoDepth depth, bool forced_depth)
           : Benchmark { "ActorBench" }
           , m_actor { LV::Actor::load (actor_name) }
       {
@@ -20,7 +24,7 @@ namespace {
           (void)height;
 
           if (!m_actor) {
-              throw std::invalid_argument ("Cannot load actor '" + actor_name);
+              throw std::invalid_argument {"Cannot load actor '"s + std::string {actor_name}};
           }
 
           m_actor->realize ();

--- a/libvisual/tools/benchmarks/benchmark.hpp
+++ b/libvisual/tools/benchmarks/benchmark.hpp
@@ -2,6 +2,7 @@
 #define _LV_TOOLS_BENCHMARK_HPP
 
 #include <string>
+#include <string_view>
 
 namespace LV {
   namespace Tools {
@@ -22,8 +23,8 @@ namespace LV {
 
     protected:
 
-        explicit Benchmark (std::string const& name)
-            : m_name (name)
+        explicit Benchmark (std::string_view name)
+            : m_name {name}
         {}
 
     private:

--- a/libvisual/tools/benchmarks/morph_bench.cpp
+++ b/libvisual/tools/benchmarks/morph_bench.cpp
@@ -3,21 +3,25 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <cstdlib>
 
 namespace {
+
+  using namespace std::string_literals;
 
   class MorphBench
       : public LV::Tools::Benchmark
   {
   public:
 
-      MorphBench (std::string const& morph_name, unsigned int width, unsigned int height, VisVideoDepth depth)
+      MorphBench (std::string_view morph_name, unsigned int width, unsigned int height, VisVideoDepth depth)
           : Benchmark { "MorphBench" }
           , m_morph { LV::Morph::load (morph_name) }
       {
           if (!m_morph) {
-              throw std::invalid_argument ("Cannot load morph " + morph_name);
+              throw std::invalid_argument {"Cannot load morph "s + std::string {morph_name}};
           }
 
           m_morph->realize ();

--- a/libvisual/tools/lv-tool/display/display.cpp
+++ b/libvisual/tools/lv-tool/display/display.cpp
@@ -28,6 +28,8 @@
 #include <stdexcept>
 #include <string>
 
+using namespace std::string_literals;
+
 class Display::Impl
 {
 public:
@@ -42,13 +44,14 @@ public:
     {}
 };
 
-Display::Display (std::string const& driver_name)
+Display::Display (std::string_view driver_name)
   : m_impl (new Impl)
 {
     m_impl->driver.reset (DisplayDriverFactory::instance().make (driver_name, *this));
 
     if (!m_impl->driver) {
-        throw std::runtime_error ("Failed to load display driver '" + driver_name + "'. Valid driver set? (\"--driver\" parameter)");
+        std::string const driver_name_str {driver_name};
+        throw std::runtime_error {"Failed to load display driver '"s + driver_name_str + "'. Valid driver set? (\"--driver\" parameter)"};
     }
 }
 
@@ -80,9 +83,9 @@ void Display::close ()
     m_impl->driver->close ();
 }
 
-void Display::set_title(std::string const& title)
+void Display::set_title(std::string_view title)
 {
-    m_impl->driver->set_title(title);
+    m_impl->driver->set_title (title);
 }
 
 void Display::lock ()

--- a/libvisual/tools/lv-tool/display/display.hpp
+++ b/libvisual/tools/lv-tool/display/display.hpp
@@ -27,7 +27,7 @@
 
 #include <libvisual/libvisual.h>
 #include <memory>
-#include <string>
+#include <string_view>
 
 class DisplayDriver;
 
@@ -35,7 +35,7 @@ class Display final
 {
 public:
 
-    explicit Display (std::string const& driver_name);
+    explicit Display (std::string_view driver_name);
 
     Display (Display const&) = delete;
 
@@ -61,7 +61,7 @@ public:
 
     LV::VideoPtr get_video () const;
 
-    void set_title(std::string const& title);
+    void set_title(std::string_view title);
 
     bool is_fullscreen () const;
 

--- a/libvisual/tools/lv-tool/display/display_driver.hpp
+++ b/libvisual/tools/lv-tool/display/display_driver.hpp
@@ -25,7 +25,7 @@
 #ifndef _LV_TOOL_DISPLAY_DRIVER_HPP
 #define _LV_TOOL_DISPLAY_DRIVER_HPP
 
-#include <string>
+#include <string_view>
 #include <libvisual/libvisual.h>
 
 class Display;
@@ -55,7 +55,7 @@ public:
 
     virtual LV::VideoPtr get_video () const = 0;
 
-    virtual void set_title(std::string const& title) = 0;
+    virtual void set_title (std::string_view title) = 0;
 
     virtual ~DisplayDriver () {}
 };

--- a/libvisual/tools/lv-tool/display/display_driver_factory.cpp
+++ b/libvisual/tools/lv-tool/display/display_driver_factory.cpp
@@ -57,14 +57,16 @@ DisplayDriverFactory::~DisplayDriverFactory ()
     // nothing to do
 }
 
-void DisplayDriverFactory::add_driver (std::string const& name, Creator const& creator)
+void DisplayDriverFactory::add_driver (std::string_view name, Creator const& creator)
 {
-    m_impl->creators[name] = creator;
+    std::string const name_str {name};
+    m_impl->creators[name_str] = creator;
 }
 
-DisplayDriver* DisplayDriverFactory::make (std::string const& name, Display& display)
+DisplayDriver* DisplayDriverFactory::make (std::string_view name, Display& display)
 {
-    auto entry = m_impl->creators.find (name);
+    std::string const name_str {name};
+    auto entry = m_impl->creators.find (name_str);
 
     if (entry == m_impl->creators.end ()) {
         return nullptr;
@@ -73,9 +75,10 @@ DisplayDriver* DisplayDriverFactory::make (std::string const& name, Display& dis
     return entry->second (display);
 }
 
-bool DisplayDriverFactory::has_driver (std::string const& name) const
+bool DisplayDriverFactory::has_driver (std::string_view name) const
 {
-    return (m_impl->creators.find (name) != m_impl->creators.end ());
+    std::string const name_str {name};
+    return (m_impl->creators.find (name_str) != m_impl->creators.end ());
 }
 
 DisplayDriverList DisplayDriverFactory::get_driver_list () const

--- a/libvisual/tools/lv-tool/display/display_driver_factory.hpp
+++ b/libvisual/tools/lv-tool/display/display_driver_factory.hpp
@@ -28,6 +28,7 @@
 #include "display_driver.hpp"
 #include <memory>
 #include <functional>
+#include <string_view>
 #include <vector>
 
 typedef std::function<DisplayDriver* (Display& display)> DisplayDriverCreator;
@@ -46,11 +47,11 @@ public:
 	    return m_instance;
     }
 
-    DisplayDriver* make (std::string const& name, Display& display);
+    DisplayDriver* make (std::string_view name, Display& display);
 
-    void add_driver (std::string const& name, Creator const& creator);
+    void add_driver (std::string_view name, Creator const& creator);
 
-    bool has_driver (std::string const& name) const;
+    bool has_driver (std::string_view name) const;
 
     DisplayDriverList get_driver_list () const;
 

--- a/libvisual/tools/lv-tool/display/sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/sdl_driver.cpp
@@ -216,9 +216,10 @@ namespace {
           return m_screen_video;
       }
 
-      void set_title(std::string const& title) override
+      void set_title (std::string_view title) override
       {
-          SDL_WM_SetCaption (title.c_str(), nullptr);
+          std::string const title_str {title};
+          SDL_WM_SetCaption (title_str.c_str (), nullptr);
       }
 
       void update_rect (LV::Rect const& rect) override

--- a/libvisual/tools/lv-tool/display/stdout_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_driver.cpp
@@ -104,7 +104,7 @@ namespace {
           return m_screen_video;
       }
 
-      void set_title(std::string const& title) override
+      void set_title (std::string_view title) override
       {
           (void)title;
 

--- a/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
+++ b/libvisual/tools/lv-tool/display/stdout_sdl_driver.cpp
@@ -233,9 +233,10 @@ namespace {
           return m_screen_video;
       }
 
-      void set_title(std::string const& title) override
+      void set_title (std::string_view title) override
       {
-          SDL_WM_SetCaption (title.c_str(), nullptr);
+          std::string title_str {title};
+          SDL_WM_SetCaption (title_str.c_str (), nullptr);
       }
 
       void update_rect (LV::Rect const& rect) override

--- a/libvisual/tools/lv-tool/lv-tool.cpp
+++ b/libvisual/tools/lv-tool/lv-tool.cpp
@@ -32,8 +32,9 @@
 #include <atomic>
 #include <stdexcept>
 #include <iostream>
-#include <unordered_set>
 #include <string>
+#include <string_view>
+#include <unordered_set>
 #include <cstdio>
 #include <cstdlib>
 #include <csignal>
@@ -211,8 +212,9 @@ namespace {
   }
 
   /** print commandline help */
-  void print_help(std::string const& name)
+  void print_help (std::string_view name)
   {
+      std::string const name_str {name};
       printf("Usage: %s [options]\n\n"
                   "Valid options:\n"
                   "\t--help\t\t\t-h\t\tThis help text\n"
@@ -230,7 +232,7 @@ namespace {
                   "\t--switch <n>\t\t-S <n>\t\tSwitch actor after n frames.\n"
                   "\t--exclude <actors>\t-x <actors>\tProvide a list of actors to exclude.\n"
                   "\n",
-                  name.c_str (),
+                  name_str.c_str (),
                   width, height,
                   driver_name.c_str (),
                   input_name.c_str (),
@@ -244,7 +246,6 @@ namespace {
         {
             printf("\t%s\n", driver_name.c_str());
         }
-
   }
 
 


### PR DESCRIPTION
`std::string_view` was introduced in C++17 to encapsulate a sequence of characters. It provides a cheap,  uniform and safe way to pass read-only strings of various types (`std::string`, `char*`, etc.).

This PR replaces string arguments of type `std::string` with `std::string_view` to make string-accepting C++ functions more flexible in their inputs, while avoiding unnecessary copies of string literals and C strings. This in particular reduces the overhead of string passing when the C API functions call into C++ Core.
