### PR TITLE
Core: Fix LV_RESTRICT not correctly defined in C++ when compiling with GCC and Clang.

### DIFF
--- a/libvisual/libvisual/lv_defines.h
+++ b/libvisual/libvisual/lv_defines.h
@@ -78,7 +78,7 @@
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define LV_RESTRICT restrict
-#elif defined(__GNUC__) && __GNU__ >= 4
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #  define LV_RESTRICT __restrict__
 #elif defined(_MSC_VER) && _MSC_VER >= 1600
 #  define LV_RESTRICT __restrict


### PR DESCRIPTION
`LV_RESTRICT` was not correctly defined when compiling with `g++` and `clang++` due to a typo in naming `__GNUC__`. This PR fixes that. This is a replacement of #266.
