### PR TITLE
[0.4.x] libvisual-plugins: Fix allocation size in "corona" to fix heap-buffer-overflow (fixes #263)

### DIFF
--- a/libvisual-plugins/plugins/actor/corona/corona.cpp
+++ b/libvisual-plugins/plugins/actor/corona/corona.cpp
@@ -106,7 +106,7 @@ bool Corona::setUpSurface(int width, int height) {
 	m_real_image = (unsigned char *)calloc(1,width*height);
 	if (m_real_image == 0) return false;
 	m_image      = m_real_image + m_width * (m_real_height - m_height);
-	m_reflArray  = (int*)malloc((m_real_height - m_height) + m_width);
+	m_reflArray  = (int*)malloc((m_real_height - m_height) * sizeof(*m_reflArray));
 
 	// Allocate the delta-field memory, and initialise it
 	m_deltafield = (unsigned char**)malloc(m_width * m_height * sizeof(unsigned char*));


### PR DESCRIPTION
Fixes #263

Turned to it could be triggered by resizing the window to be of tiny width.

`m_reflArray` is an array of int elements and all loops operate on `m_real_height - m_height` elements.  So if the loop code is correct, then we need `(m_real_height - m_height) * sizeof(int)` many bytes for `m_reflArray`.

Symptom through the eyes of AddressSanitizer:
> ```
> =================================================================
> ==20990==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61400000cbec at pc 0x7fe65de62216 bp 0x7ffd745ec810 sp 0x7ffd745ec808
> WRITE of size 4 at 0x61400000cbec thread T0
>     #0 0x7fe65de62215 in Corona::genReflectedWaves(double) [..]/libvisual-plugins/plugins/actor/corona/corona.cpp:311
>     #1 0x7fe65de62262 in Corona::drawReflected() [..]/libvisual-plugins/plugins/actor/corona/corona.cpp:317
>     #2 0x7fe65de6369f in Corona::update(TimedLevel*) [..]/libvisual-plugins/plugins/actor/corona/corona.cpp:504
>     #3 0x7fe65de5fe22 in lv_corona_render [..]/libvisual-plugins/plugins/actor/corona/actor_corona.cpp:278
>     #4 0x7fe66286edb4 in visual_actor_run [..]/libvisual/libvisual/lv_actor.c:783
>     #5 0x7fe662874aac in visual_bin_run [..]/libvisual/libvisual/lv_bin.c:867
>     #6 0x55a1ec4d51ee in LV::Bin::run() [..]/libvisual/tools/lv-tool/lv-tool.cpp:111
>     #7 0x55a1ec4d51ee in main [..]/libvisual/tools/lv-tool/lv-tool.cpp:869
>     #8 0x7fe6624a8d09 in __libc_start_main ../csu/libc-start.c:308
>     #9 0x55a1ec4d2889 in _start ([..]/INSTALL_PREFIX/bin/lv-tool+0x5889)
>
> 0x61400000cbec is located 0 bytes to the right of 428-byte region [0x61400000ca40,0x61400000cbec)
> allocated by thread T0 here:
>     #0 0x7fe662a2ae8f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
>     #1 0x7fe65de612d2 in Corona::setUpSurface(int, int) [..]/libvisual-plugins/plugins/actor/corona/corona.cpp:109
>     #2 0x7fe65de602ed in lv_corona_dimension [..]/libvisual-plugins/plugins/actor/corona/actor_corona.cpp:198
>     #3 0x7fe65de604a9 in lv_corona_events [..]/libvisual-plugins/plugins/actor/corona/actor_corona.cpp:210
>     #4 0x7fe662875b94 in visual_plugin_events_pump [..]/libvisual/libvisual/lv_plugin.c:241
>     #5 0x7fe66286e6d2 in negotiate_video [..]/libvisual/libvisual/lv_actor.c:613
>     #6 0x7fe66286e6d2 in visual_actor_video_negotiate [..]/libvisual/libvisual/lv_actor.c:538
>     #7 0x7fe6628718c4 in visual_bin_sync [..]/libvisual/libvisual/lv_bin.c:346
>     #8 0x55a1ec4d640f in LV::Bin::sync(bool) [..]/libvisual/tools/lv-tool/lv-tool.cpp:103
>     #9 0x55a1ec4d640f in main [..]/libvisual/tools/lv-tool/lv-tool.cpp:926
>     #10 0x7fe6624a8d09 in __libc_start_main ../csu/libc-start.c:308
>
> SUMMARY: AddressSanitizer: heap-buffer-overflow [..]/libvisual-plugins/plugins/actor/corona/corona.cpp:311 in Corona::genReflectedWaves(double)
> Shadow bytes around the buggy address:
>   0x0c287fff9920: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
>   0x0c287fff9930: 00 00 00 00 00 00 00 00 00 00 00 00 06 fa fa fa
>   0x0c287fff9940: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
>   0x0c287fff9950: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
>   0x0c287fff9960: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
> =>0x0c287fff9970: 00 00 00 00 00 00 00 00 00 00 00 00 00[04]fa fa
>   0x0c287fff9980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
>   0x0c287fff9990: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
>   0x0c287fff99a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
>   0x0c287fff99b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
>   0x0c287fff99c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
> Shadow byte legend (one shadow byte represents 8 application bytes):
>   Addressable:           00
>   Partially addressable: 01 02 03 04 05 06 07
>   Heap left redzone:       fa
>   Freed heap region:       fd
>   Stack left redzone:      f1
>   Stack mid redzone:       f2
>   Stack right redzone:     f3
>   Stack after return:      f5
>   Stack use after scope:   f8
>   Global redzone:          f9
>   Global init order:       f6
>   Poisoned by user:        f7
>   Container overflow:      fc
>   Array cookie:            ac
>   Intra object redzone:    bb
>   ASan internal:           fe
>   Left alloca redzone:     ca
>   Right alloca redzone:    cb
>   Shadow gap:              cc
> ==20990==ABORTING
> ```