### PR TITLE
Core: Enhance and clean up singleton classes

### DIFF
--- a/libvisual/libvisual/lv_libvisual.cpp
+++ b/libvisual/libvisual/lv_libvisual.cpp
@@ -97,17 +97,14 @@ namespace LV
       };
   }
 
-  template <>
-  LV_API System* Singleton<System>::m_instance = nullptr;
-
   void System::init (int& argc, char**& argv)
   {
       if (m_instance) {
-          visual_log (VISUAL_LOG_WARNING, "Attempt to initialize LV a second time");
+          visual_log (VISUAL_LOG_WARNING, "Attempt to initialize LV a second time.");
           return;
       }
 
-      m_instance = new System (argc, argv);
+      m_instance.reset (new System {argc, argv});
   }
 
   std::string System::get_version () const
@@ -136,7 +133,7 @@ namespace LV
   }
 
   System::System (int& argc, char**& argv)
-      : m_impl(new Impl)
+      : m_impl {std::make_unique<Impl> ()}
   {
       (void)argc;
       (void)argv;

--- a/libvisual/libvisual/lv_libvisual.h
+++ b/libvisual/libvisual/lv_libvisual.h
@@ -41,11 +41,7 @@
 //! Libvisual namespace
 namespace LV {
 
-  class LV_API System;
-  template <>
-  LV_API System* Singleton<System>::m_instance;
-
-  class LV_API System
+  class LV_API System final
       : public Singleton<System>
   {
   public:
@@ -60,7 +56,7 @@ namespace LV {
 
       System (System const&) = delete;
 
-      virtual ~System ();
+      ~System () override;
 
       /**
        * Returns the Libvisual version.

--- a/libvisual/libvisual/lv_plugin_registry.cpp
+++ b/libvisual/libvisual/lv_plugin_registry.cpp
@@ -79,17 +79,18 @@ namespace LV {
       return ref;
   }
 
-  template <>
-  LV_API PluginRegistry* Singleton<PluginRegistry>::m_instance = nullptr;
-
   void PluginRegistry::init ()
   {
-      if (!m_instance)
-          m_instance = new PluginRegistry;
+      if (m_instance) {
+          visual_log (VISUAL_LOG_WARNING, "Attempt to initialize plugin registry a second time.");
+          return;
+      }
+
+      m_instance.reset (new PluginRegistry {});
   }
 
   PluginRegistry::PluginRegistry ()
-      : m_impl (new Impl)
+      : m_impl {std::make_unique<Impl> ()}
   {
       visual_log (VISUAL_LOG_DEBUG, "Initializing plugin registry");
 

--- a/libvisual/libvisual/lv_plugin_registry.h
+++ b/libvisual/libvisual/lv_plugin_registry.h
@@ -16,15 +16,13 @@ namespace LV {
   typedef ::VisPluginType PluginType;
 
   class LV_API PluginRegistry;
-  template<>
-  LV_API PluginRegistry* Singleton<PluginRegistry>::m_instance;
 
   //! Manages the registry of plugins
   //!
   //! @note This is a singleton class. Its only instance must
   //!       be accessed via the instance() method.
   //!
-  class LV_API PluginRegistry
+  class LV_API PluginRegistry final
       : public Singleton<PluginRegistry>
   {
   public:
@@ -32,7 +30,7 @@ namespace LV {
       PluginRegistry (PluginRegistry const&) = delete;
 
       /** Destructor */
-      virtual ~PluginRegistry ();
+      ~PluginRegistry () override;
 
       /**
        * Adds an extra plugin search path.

--- a/libvisual/libvisual/lv_singleton.hpp
+++ b/libvisual/libvisual/lv_singleton.hpp
@@ -31,6 +31,14 @@ namespace LV {
           return m_instance.get ();
       }
 
+      //! Returns the singleton instance as const.
+      //!
+      //! @return Singleton instance.
+      static T const* const_instance ()
+      {
+          return m_instance.get ();
+      }
+
       //! Destroys the singleton instance
       static void destroy ()
       {

--- a/libvisual/libvisual/lv_singleton.hpp
+++ b/libvisual/libvisual/lv_singleton.hpp
@@ -1,6 +1,8 @@
 #ifndef _LV_SINGLETON_HPP
 #define _LV_SINGLETON_HPP
 
+#include <memory>
+
 namespace LV {
 
   //! Singleton class template.
@@ -24,23 +26,26 @@ namespace LV {
       //! Returns the singleton instance
       //!
       //! @return singleton instance
-      static T* instance () {
-          return m_instance;
+      static T* instance ()
+      {
+          return m_instance.get ();
       }
 
       //! Destroys the singleton instance
       static void destroy ()
       {
-          delete m_instance;
-          m_instance = nullptr;
+          m_instance.reset ();
       }
 
   protected:
 
-      static T* m_instance;
+      static std::unique_ptr<T> m_instance;
 
       Singleton () = default;
   };
+
+  template <class T>
+  std::unique_ptr<T> Singleton<T>::m_instance {};
 
 } // LV namespace
 

--- a/libvisual/libvisual/lv_singleton.hpp
+++ b/libvisual/libvisual/lv_singleton.hpp
@@ -39,13 +39,10 @@ namespace LV {
 
   protected:
 
-      static std::unique_ptr<T> m_instance;
+      inline static std::unique_ptr<T> m_instance {};
 
       Singleton () = default;
   };
-
-  template <class T>
-  std::unique_ptr<T> Singleton<T>::m_instance {};
 
 } // LV namespace
 


### PR DESCRIPTION
- Use `std::unique_ptr<>` to hold instance pointers.
- Mark singleton classes `final` to enable devirtualization.