### PR TITLE
Core (Memory): Remove custom implementations of memset() and memcpy().

### DIFF
--- a/libvisual/libvisual/lv_mem.c
+++ b/libvisual/libvisual/lv_mem.c
@@ -25,30 +25,16 @@
 #include "lv_common.h"
 #include "lv_cpu.h"
 #include "lv_bits.h"
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* Standard C fallbacks */
-static void *mem_copy_c (void *dest, const void *src, visual_size_t n);
-static void *mem_set8_c (void *dest, int c, visual_size_t n);
 static void *mem_set16_c (void *dest, int c, visual_size_t n);
 static void *mem_set32_c (void *dest, int c, visual_size_t n);
 static void *mem_copy_pitch_c (void *dest, const void *src, int pitch1, int pitch2, int width, int rows);
 
-
 /* x86 SIMD optimized versions */
 #if defined(VISUAL_ARCH_X86) || defined(VISUAL_ARCH_X86_64)
-static void *mem_copy_3dnow (void *dest, const void *src, visual_size_t n);
-static void *mem_copy_mmx (void *dest, const void *src, visual_size_t n);
-static void *mem_copy_mmx2 (void *dest, const void *src, visual_size_t n);
-
-static void *mem_copy_pitch_mmx (void *dest, const void *src, int pitch1, int pitch2, int width, int rows);
-static void *mem_copy_pitch_mmx2 (void *dest, const void *src, int pitch1, int pitch2, int width, int rows);
-static void *mem_copy_pitch_3dnow (void *dest, const void *src, int pitch1, int pitch2, int width, int rows);
-
-static void *mem_set8_mmx (void *dest, int c, visual_size_t n);
-static void *mem_set8_mmx2 (void *dest, int c, visual_size_t n);
-
 static void *mem_set16_mmx (void *dest, int c, visual_size_t n);
 static void *mem_set16_mmx2 (void *dest, int c, visual_size_t n);
 
@@ -58,10 +44,10 @@ static void *mem_set32_mmx2 (void *dest, int c, visual_size_t n);
 
 
 /* Optimal performance functions set by visual_mem_initialize(). */
-VisMemCopyFunc visual_mem_copy = mem_copy_c;
+VisMemCopyFunc visual_mem_copy = memcpy;
 VisMemCopyPitchFunc visual_mem_copy_pitch = mem_copy_pitch_c;
 
-VisMemSet8Func visual_mem_set = mem_set8_c;
+VisMemSet8Func visual_mem_set = memset;
 VisMemSet16Func visual_mem_set16 = mem_set16_c;
 VisMemSet32Func visual_mem_set32 = mem_set32_c;
 
@@ -71,36 +57,17 @@ void visual_mem_initialize ()
 	/* Arranged from slow to fast, so the slower version gets overloaded
 	 * every time */
 
-	visual_mem_copy = mem_copy_c;
-	visual_mem_copy_pitch = mem_copy_pitch_c;
-
-	visual_mem_set = mem_set8_c;
-	visual_mem_set16 = mem_set16_c;
-	visual_mem_set32 = mem_set32_c;
-
 #if defined(VISUAL_ARCH_X86) || defined(VISUAL_ARCH_X86_64)
 
 	if (visual_cpu_has_mmx ()) {
-		visual_mem_copy = mem_copy_mmx;
-		visual_mem_copy_pitch = mem_copy_pitch_mmx;
-
-		visual_mem_set = mem_set8_mmx;
 		visual_mem_set16 = mem_set16_mmx;
 		visual_mem_set32 = mem_set32_mmx;
 	}
 
 	/* The k6-II and k6-III don't have mmx2, but of course can use the prefetch
 	 * facility that 3dnow provides. */
-	if (visual_cpu_has_3dnow ()) {
-		visual_mem_copy = mem_copy_3dnow;
-		visual_mem_copy_pitch = mem_copy_pitch_3dnow;
-	}
 
 	if (visual_cpu_has_mmx2 ()) {
-		visual_mem_copy = mem_copy_mmx2;
-		visual_mem_copy_pitch = mem_copy_pitch_mmx2;
-
-		visual_mem_set = mem_set8_mmx2;
 		visual_mem_set16 = mem_set16_mmx2;
 		visual_mem_set32 = mem_set32_mmx2;
 	}
@@ -148,17 +115,6 @@ void visual_mem_free (void *ptr)
 	free (ptr);
 }
 
-static void *mem_copy_c (void *dest, const void *src, visual_size_t n)
-{
-	return memcpy(dest, src, n);
-}
-
-/* Memset functions, 1 byte memset */
-static void *mem_set8_c (void *dest, int c, visual_size_t n)
-{
-	return memset(dest, c, n);
-}
-
 /* Memset functions, 2 byte memset */
 static void *mem_set16_c (void *dest, int c, visual_size_t n)
 {
@@ -194,7 +150,6 @@ static void *mem_set32_c (void *dest, int c, visual_size_t n)
 	return dest;
 }
 
-
 /* Memcopy with pitch functions */
 static void *mem_copy_pitch_c (void *dest, const void *src, int pitch1, int pitch2, int row_bytes, int rows)
 {
@@ -212,493 +167,7 @@ static void *mem_copy_pitch_c (void *dest, const void *src, int pitch1, int pitc
 	return dest;
 }
 
-
 #if defined(VISUAL_ARCH_X86) || defined(VISUAL_ARCH_X86_64)
-
-static void *mem_copy_mmx (void *dest, const void *src, visual_size_t n)
-{
-	uint32_t *d = dest;
-	const uint32_t *s = src;
-	uint8_t *dc = dest;
-	const uint8_t *sc = src;
-
-	while (n >= 64) {
-		__asm __volatile
-			("\n\t movq (%0), %%mm0"
-			 "\n\t movq 8(%0), %%mm1"
-			 "\n\t movq 16(%0), %%mm2"
-			 "\n\t movq 24(%0), %%mm3"
-			 "\n\t movq 32(%0), %%mm4"
-			 "\n\t movq 40(%0), %%mm5"
-			 "\n\t movq 48(%0), %%mm6"
-			 "\n\t movq 56(%0), %%mm7"
-			 "\n\t movq %%mm0, (%1)"
-			 "\n\t movq %%mm1, 8(%1)"
-			 "\n\t movq %%mm2, 16(%1)"
-			 "\n\t movq %%mm3, 24(%1)"
-			 "\n\t movq %%mm4, 32(%1)"
-			 "\n\t movq %%mm5, 40(%1)"
-			 "\n\t movq %%mm6, 48(%1)"
-			 "\n\t movq %%mm7, 56(%1)"
-			 :: "r" (s), "r" (d) : "memory");
-
-		d += 16;
-		s += 16;
-
-		n -= 64;
-	}
-
-	__asm __volatile
-		("\n\t emms");
-
-	while (n >= 4) {
-		*d++ = *s++;
-		n -= 4;
-	}
-
-	dc = (uint8_t *) d;
-	sc = (const uint8_t *) s;
-
-	while (n--)
-		*dc++ = *sc++;
-
-	return dest;
-}
-
-static void *mem_copy_mmx2 (void *dest, const void *src, visual_size_t n)
-{
-	uint32_t *d = dest;
-	const uint32_t *s = src;
-	uint8_t *dc = dest;
-	const uint8_t *sc = src;
-
-	while (n >= 64) {
-		__asm __volatile
-			("\n\t prefetchnta 256(%0)"
-			 "\n\t prefetchnta 320(%0)"
-			 "\n\t movq (%0), %%mm0"
-			 "\n\t movq 8(%0), %%mm1"
-			 "\n\t movq 16(%0), %%mm2"
-			 "\n\t movq 24(%0), %%mm3"
-			 "\n\t movq 32(%0), %%mm4"
-			 "\n\t movq 40(%0), %%mm5"
-			 "\n\t movq 48(%0), %%mm6"
-			 "\n\t movq 56(%0), %%mm7"
-			 "\n\t movntq %%mm0, (%1)"
-			 "\n\t movntq %%mm1, 8(%1)"
-			 "\n\t movntq %%mm2, 16(%1)"
-			 "\n\t movntq %%mm3, 24(%1)"
-			 "\n\t movntq %%mm4, 32(%1)"
-			 "\n\t movntq %%mm5, 40(%1)"
-			 "\n\t movntq %%mm6, 48(%1)"
-			 "\n\t movntq %%mm7, 56(%1)"
-			 :: "r" (s), "r" (d) : "memory");
-
-		d += 16;
-		s += 16;
-
-		n -= 64;
-	}
-
-	__asm __volatile
-		("\n\t emms");
-
-	while (n >= 4) {
-		*d++ = *s++;
-		n -= 4;
-	}
-
-	dc = (uint8_t *) d;
-	sc = (const uint8_t *) s;
-
-	while (n--)
-		*dc++ = *sc++;
-
-	return dest;
-}
-
-static void *mem_copy_3dnow (void *dest, const void *src, visual_size_t n)
-{
-	uint32_t *d = dest;
-	const uint32_t *s = src;
-	uint8_t *dc = dest;
-	const uint8_t *sc = src;
-
-	while (n >= 64) {
-		__asm __volatile
-			("\n\t prefetch 256(%0)"
-			 "\n\t prefetch 320(%0)"
-			 "\n\t movq (%0), %%mm0"
-			 "\n\t movq 8(%0), %%mm1"
-			 "\n\t movq 16(%0), %%mm2"
-			 "\n\t movq 24(%0), %%mm3"
-			 "\n\t movq 32(%0), %%mm4"
-			 "\n\t movq 40(%0), %%mm5"
-			 "\n\t movq 48(%0), %%mm6"
-			 "\n\t movq 56(%0), %%mm7"
-			 "\n\t movq %%mm0, (%1)"
-			 "\n\t movq %%mm1, 8(%1)"
-			 "\n\t movq %%mm2, 16(%1)"
-			 "\n\t movq %%mm3, 24(%1)"
-			 "\n\t movq %%mm4, 32(%1)"
-			 "\n\t movq %%mm5, 40(%1)"
-			 "\n\t movq %%mm6, 48(%1)"
-			 "\n\t movq %%mm7, 56(%1)"
-			 :: "r" (s), "r" (d) : "memory");
-
-		d += 16;
-		s += 16;
-
-		n -= 64;
-	}
-
-	__asm __volatile
-		("\n\t emms");
-
-	while (n >= 4) {
-		*d++ = *s++;
-		n -= 4;
-	}
-
-	dc = (uint8_t *) d;
-	sc = (const uint8_t *) s;
-
-	while (n--)
-		*dc++ = *sc++;
-
-	return dest;
-}
-
-
-static void *mem_copy_pitch_mmx (void *dest, const void *src, int pitch1, int pitch2, int width, int rows)
-{
-	uint32_t *d = dest;
-	const uint32_t *s = src;
-	int i;
-
-	for (i = 0; i < rows; i++) {
-		uint32_t *inner_d;
-		const uint32_t *inner_s;
-		uint8_t *inner_dc = (uint8_t*) d;
-		const uint8_t *inner_sc = (const uint8_t*) s;
-		int n = width;
-
-                while (!VISUAL_ALIGNED(inner_dc, 4) && n > 4) {
-			*inner_dc++ = *inner_sc++;
-			n--;
-		}
-
-		inner_d = (uint32_t*) inner_dc;
-		inner_s = (const uint32_t*) inner_sc;
-
-#if defined(VISUAL_ARCH_X86) || defined(VISUAL_ARCH_X86_64)
-		while (n >= 64) {
-			__asm __volatile
-				("\n\t movq (%0), %%mm0"
-				 "\n\t movq 8(%0), %%mm1"
-				 "\n\t movq 16(%0), %%mm2"
-				 "\n\t movq 24(%0), %%mm3"
-				 "\n\t movq 32(%0), %%mm4"
-				 "\n\t movq 40(%0), %%mm5"
-				 "\n\t movq 48(%0), %%mm6"
-				 "\n\t movq 56(%0), %%mm7"
-				 "\n\t movq %%mm0, (%1)"
-				 "\n\t movq %%mm1, 8(%1)"
-				 "\n\t movq %%mm2, 16(%1)"
-				 "\n\t movq %%mm3, 24(%1)"
-				 "\n\t movq %%mm4, 32(%1)"
-				 "\n\t movq %%mm5, 40(%1)"
-				 "\n\t movq %%mm6, 48(%1)"
-				 "\n\t movq %%mm7, 56(%1)"
-				 :: "r" (inner_s), "r" (inner_d) : "memory");
-
-			inner_d += 16;
-			inner_s += 16;
-
-			n -= 64;
-		}
-
-		__asm __volatile
-			("\n\t emms");
-#endif /* VISUAL_ARCH_X86 */
-
-		while (n >= 4) {
-			*inner_d++ = *inner_s++;
-			n -= 4;
-		}
-
-		inner_dc = (uint8_t*) inner_d;
-		inner_sc = (const uint8_t*) inner_s;
-
-		while (n--)
-			*inner_dc++ = *inner_sc++;
-
-		d = (uint32_t*)((uint8_t*) d + pitch1);
-		s = (const uint32_t*)((const uint8_t*) s + pitch2);
-	}
-
-	return dest;
-}
-
-static void *mem_copy_pitch_mmx2 (void *dest, const void *src, int pitch1, int pitch2, int width, int rows)
-{
-	uint32_t *d = dest;
-	const uint32_t *s = src;
-	int i;
-
-	for (i = 0; i < rows; i++) {
-		uint32_t *inner_d;
-		const uint32_t *inner_s;
-		uint8_t *inner_dc = (uint8_t*) d;
-		const uint8_t *inner_sc = (const uint8_t*) s;
-		int n = width;
-
-                while (!VISUAL_ALIGNED(inner_dc, 4) && n > 4) {
-			*inner_dc++ = *inner_sc++;
-			n--;
-		}
-
-		inner_d = (uint32_t*) inner_dc;
-		inner_s = (const uint32_t*) inner_sc;
-
-#if defined(VISUAL_ARCH_X86) || defined(VISUAL_ARCH_X86_64)
-		while (n >= 64) {
-			__asm __volatile
-				("\n\t prefetchnta 256(%0)"
-				 "\n\t prefetchnta 320(%0)"
-				 "\n\t movq (%0), %%mm0"
-				 "\n\t movq 8(%0), %%mm1"
-				 "\n\t movq 16(%0), %%mm2"
-				 "\n\t movq 24(%0), %%mm3"
-				 "\n\t movq 32(%0), %%mm4"
-				 "\n\t movq 40(%0), %%mm5"
-				 "\n\t movq 48(%0), %%mm6"
-				 "\n\t movq 56(%0), %%mm7"
-				 "\n\t movntq %%mm0, (%1)"
-				 "\n\t movntq %%mm1, 8(%1)"
-				 "\n\t movntq %%mm2, 16(%1)"
-				 "\n\t movntq %%mm3, 24(%1)"
-				 "\n\t movntq %%mm4, 32(%1)"
-				 "\n\t movntq %%mm5, 40(%1)"
-				 "\n\t movntq %%mm6, 48(%1)"
-				 "\n\t movntq %%mm7, 56(%1)"
-				 :: "r" (inner_s), "r" (inner_d) : "memory");
-
-			inner_d += 16;
-			inner_s += 16;
-
-			n -= 64;
-		}
-
-		__asm __volatile
-			("\n\t emms");
-#endif /* VISUAL_ARCH_X86 */
-
-		while (n >= 4) {
-			*inner_d++ = *inner_s++;
-			n -= 4;
-		}
-
-		inner_dc = (uint8_t*) inner_d;
-		inner_sc = (const uint8_t*) inner_s;
-
-		while (n--)
-			*inner_dc++ = *inner_sc++;
-
-		d = (uint32_t*)((uint8_t*) d + pitch1);
-		s = (const uint32_t*)((const uint8_t*) s + pitch2);
-	}
-
-	return dest;
-}
-
-static void *mem_copy_pitch_3dnow (void *dest, const void *src, int pitch1, int pitch2, int width, int rows)
-{
-	uint32_t *d = dest;
-	const uint32_t *s = src;
-	int i;
-
-	for (i = 0; i < rows; i++) {
-		uint32_t *inner_d;
-		const uint32_t *inner_s;
-		uint8_t *inner_dc = (uint8_t*) d;
-		const uint8_t *inner_sc = (const uint8_t*) s;
-		int n = width;
-
-                while (!VISUAL_ALIGNED(inner_dc, 4) && n > 4) {
-			*inner_dc++ = *inner_sc++;
-			n--;
-		}
-
-		inner_d = (uint32_t*) inner_dc;
-		inner_s = (const uint32_t*) inner_sc;
-
-#if defined(VISUAL_ARCH_X86) || defined(VISUAL_ARCH_X86_64)
-		while (n >= 64) {
-			__asm __volatile
-				("\n\t prefetch 256(%0)"
-				 "\n\t prefetch 320(%0)"
-				 "\n\t movq (%0), %%mm0"
-				 "\n\t movq 8(%0), %%mm1"
-				 "\n\t movq 16(%0), %%mm2"
-				 "\n\t movq 24(%0), %%mm3"
-				 "\n\t movq 32(%0), %%mm4"
-				 "\n\t movq 40(%0), %%mm5"
-				 "\n\t movq 48(%0), %%mm6"
-				 "\n\t movq 56(%0), %%mm7"
-				 "\n\t movq %%mm0, (%1)"
-				 "\n\t movq %%mm1, 8(%1)"
-				 "\n\t movq %%mm2, 16(%1)"
-				 "\n\t movq %%mm3, 24(%1)"
-				 "\n\t movq %%mm4, 32(%1)"
-				 "\n\t movq %%mm5, 40(%1)"
-				 "\n\t movq %%mm6, 48(%1)"
-				 "\n\t movq %%mm7, 56(%1)"
-				 :: "r" (inner_s), "r" (inner_d) : "memory");
-
-			inner_d += 16;
-			inner_s += 16;
-
-			n -= 64;
-		}
-
-		__asm __volatile
-			("\n\t emms");
-#endif /* VISUAL_ARCH_X86 */
-
-		while (n >= 4) {
-			*inner_d++ = *inner_s++;
-			n -= 4;
-		}
-
-		inner_dc = (uint8_t*) inner_d;
-		inner_sc = (const uint8_t*) inner_s;
-
-		while (n--)
-			*inner_dc++ = *inner_sc++;
-
-		d = (uint32_t*)((uint8_t*) d + pitch1);
-		s = (const uint32_t*)((const uint8_t*) s + pitch2);
-	}
-
-	return dest;
-}
-
-static void *mem_set8_mmx (void *dest, int c, visual_size_t n)
-{
-	uint32_t *d = dest;
-	uint8_t *dc = dest;
-	uint32_t setflag32 =
-		(c & 0xff) |
-		((c << 8) & 0xff00) |
-		((c << 16) & 0xff0000) |
-		((c << 24) & 0xff000000);
-	uint8_t setflag8 = c & 0xff;
-
-	__asm __volatile
-		("\n\t movd (%0), %%mm0"
-		 "\n\t movd (%0), %%mm1"
-		 "\n\t psllq $32, %%mm1"
-		 "\n\t por %%mm1, %%mm0"
-		 "\n\t movq %%mm0, %%mm2"
-		 "\n\t movq %%mm0, %%mm1"
-		 "\n\t movq %%mm2, %%mm3"
-		 "\n\t movq %%mm1, %%mm4"
-		 "\n\t movq %%mm0, %%mm5"
-		 "\n\t movq %%mm2, %%mm6"
-		 "\n\t movq %%mm1, %%mm7"
-		 :: "r" (&setflag32) : "memory");
-
-	while (n >= 64) {
-		__asm __volatile
-			("\n\t movq %%mm0, (%0)"
-			 "\n\t movq %%mm1, 8(%0)"
-			 "\n\t movq %%mm2, 16(%0)"
-			 "\n\t movq %%mm3, 24(%0)"
-			 "\n\t movq %%mm4, 32(%0)"
-			 "\n\t movq %%mm5, 40(%0)"
-			 "\n\t movq %%mm6, 48(%0)"
-			 "\n\t movq %%mm7, 56(%0)"
-			 :: "r" (d) : "memory");
-
-		d += 16;
-
-		n -= 64;
-	}
-
-	__asm __volatile
-		("\n\t emms");
-
-	while (n >= 4) {
-		*d++ = setflag32;
-		n -= 4;
-	}
-
-	dc = (uint8_t *) d;
-
-	while (n--)
-		*dc++ = setflag8;
-
-	return dest;
-}
-
-static void *mem_set8_mmx2 (void *dest, int c, visual_size_t n)
-{
-	uint32_t *d = dest;
-	uint8_t *dc = dest;
-	uint32_t setflag32 =
-		(c & 0xff) |
-		((c << 8) & 0xff00) |
-		((c << 16) & 0xff0000) |
-		((c << 24) & 0xff000000);
-	uint8_t setflag8 = c & 0xff;
-
-	__asm __volatile
-		("\n\t movd (%0), %%mm0"
-		 "\n\t movd (%0), %%mm1"
-		 "\n\t psllq $32, %%mm1"
-		 "\n\t por %%mm1, %%mm0"
-		 "\n\t movq %%mm0, %%mm2"
-		 "\n\t movq %%mm0, %%mm1"
-		 "\n\t movq %%mm2, %%mm3"
-		 "\n\t movq %%mm1, %%mm4"
-		 "\n\t movq %%mm0, %%mm5"
-		 "\n\t movq %%mm2, %%mm6"
-		 "\n\t movq %%mm1, %%mm7"
-		 :: "r" (&setflag32) : "memory");
-
-	while (n >= 64) {
-		__asm __volatile
-			("\n\t movntq %%mm0, (%0)"
-			 "\n\t movntq %%mm1, 8(%0)"
-			 "\n\t movntq %%mm2, 16(%0)"
-			 "\n\t movntq %%mm3, 24(%0)"
-			 "\n\t movntq %%mm4, 32(%0)"
-			 "\n\t movntq %%mm5, 40(%0)"
-			 "\n\t movntq %%mm6, 48(%0)"
-			 "\n\t movntq %%mm7, 56(%0)"
-			 :: "r" (d) : "memory");
-
-		d += 16;
-
-		n -= 64;
-	}
-
-	__asm __volatile
-		("\n\t emms");
-
-	while (n >= 4) {
-		*d++ = setflag32;
-		n -= 4;
-	}
-
-	dc = (uint8_t *) d;
-
-	while (n--)
-		*dc++ = setflag8;
-
-	return dest;
-}
 
 static void *mem_set16_mmx (void *dest, int c, visual_size_t n)
 {


### PR DESCRIPTION
This closes #275.