### PR TITLE
[0.4.x] libvisual-plugins: Fix compile error for actor "gforce" (e.g. for macOS)

### DIFF
--- a/libvisual-plugins/plugins/actor/G-Force/GForceCommon/G-Force.cpp
+++ b/libvisual-plugins/plugins/actor/G-Force/GForceCommon/G-Force.cpp
@@ -1386,7 +1386,7 @@ void GForce::SpawnNewParticle() {
 
 	
 
-void GForce::Print( char* inStr ) {
+void GForce::Print( const char* inStr ) {
 	long num = mConsoleLines.Count();
 	UtilStr* lastLine = mConsoleLines.Fetch( num );
 	
@@ -1406,7 +1406,7 @@ void GForce::Print( char* inStr ) {
 }
 
 
-void GForce::Println( char* inStr ) {
+void GForce::Println( const char* inStr ) {
 	Print( inStr );
 	
 	mConsoleLines.Add( "" );

--- a/libvisual-plugins/plugins/actor/G-Force/GForceCommon/Headers/G-Force.h
+++ b/libvisual-plugins/plugins/actor/G-Force/GForceCommon/Headers/G-Force.h
@@ -143,10 +143,10 @@ class GForce {
 		long					mConsoleLineDur;
 		long					mConsoleExpireTime;
 		void					DrawConsole();
-		void					Print( char* inStr );
-		void					Print( UtilStr* inStr )											{ if ( inStr ) Print( inStr -> getCStr() );		}
-		void					Println( char* inStr );
-		void					Println( UtilStr* inStr )										{ Println( inStr ? inStr -> getCStr() : 0 ); }
+		void					Print( const char* inStr );
+		void					Print( const UtilStr* inStr )											{ if ( inStr ) Print( inStr -> getCStr() );		}
+		void					Println( const char* inStr );
+		void					Println( const UtilStr* inStr )										{ Println( inStr ? inStr -> getCStr() : 0 ); }
 				
 		// Palette stuff
 		PixPalEntry				mPalette[ 256 ];


### PR DESCRIPTION
Extracted from #262.