### PR TITLE
[0.4.x] libvisual + libvisual-plugins: React to macos-11 gcc-9 removal

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -31,8 +31,8 @@ jobs:
             clang_repo_suffix:
             runs-on: ubuntu-latest
         # macOS
-          - cc: gcc-9
-            cxx: g++-9
+          - cc: gcc-10
+            cxx: g++-10
             clang_major_version: null
             clang_repo_suffix: null
             runs-on: macos-11


### PR DESCRIPTION
Related: https://github.com/actions/runner-images/issues/7136