### PR TITLE
[0.4.x] libvisual + libvisual-plugins: Mass-fix typo "[Tt]ransparant" once more

### DIFF
--- a/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.cpp
+++ b/libvisual-plugins/plugins/actor/dancingparticles/actor_dancingparticles.cpp
@@ -128,7 +128,7 @@ extern "C" int lv_dancingparticles_init (VisPluginData *plugin)
 
 	visual_param_container_add_many (paramcontainer, params);
 
-	checkbox = visual_ui_checkbox_new ("Transparant bars", TRUE);
+	checkbox = visual_ui_checkbox_new ("Transparent bars", TRUE);
 	visual_ui_mutator_set_param (VISUAL_UI_MUTATOR (checkbox), visual_param_container_get (paramcontainer, "transparent bars"));
 
 	visual_plugin_set_userinterface (plugin, checkbox);

--- a/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
+++ b/libvisual-plugins/plugins/actor/lv_gltest/actor_lv_gltest.c
@@ -151,7 +151,7 @@ int lv_gltest_init (VisPluginData *plugin)
 
 	visual_param_container_add_many (paramcontainer, params);
 
-	checkbox = visual_ui_checkbox_new (_("Transparant bars"), TRUE);
+	checkbox = visual_ui_checkbox_new (_("Transparent bars"), TRUE);
 	visual_ui_mutator_set_param (VISUAL_UI_MUTATOR (checkbox), visual_param_container_get (paramcontainer, "transparent bars"));
 
 	visual_plugin_set_userinterface (plugin, checkbox);

--- a/libvisual-plugins/po/de.po
+++ b/libvisual-plugins/po/de.po
@@ -309,9 +309,8 @@ msgstr "Libvisual-GL-Analysiererweiterung"
 msgid "This plugin shows an openGL bar analyzer like the xmms one"
 msgstr "Diese Erweiterung zeigt ein OpenGL-Balkenanalyse wie die von XMMS."
 
-# FIXME s/Transparant/Transparent/
 #: plugins/actor/lv_gltest/actor_lv_gltest.c:154
-msgid "Transparant bars"
+msgid "Transparent bars"
 msgstr "durchsichtige Balken"
 
 #: plugins/actor/lv_scope/actor_lv_scope.c:68

--- a/libvisual-plugins/po/es_AR.po
+++ b/libvisual-plugins/po/es_AR.po
@@ -302,7 +302,7 @@ msgid "This plugin shows an openGL bar analyzer like the xmms one"
 msgstr "Éste plugin muestra un analizador de barras OpenGL como el de xmms"
 
 #: plugins/actor/lv_gltest/actor_lv_gltest.c:154
-msgid "Transparant bars"
+msgid "Transparent bars"
 msgstr "Barras transparentes"
 
 #: plugins/actor/lv_scope/actor_lv_scope.c:68

--- a/libvisual-plugins/po/es_ES.po
+++ b/libvisual-plugins/po/es_ES.po
@@ -302,7 +302,7 @@ msgid "This plugin shows an openGL bar analyzer like the xmms one"
 msgstr "Éste plugin muestra un analizador de barras OpenGL como el de xmms"
 
 #: plugins/actor/lv_gltest/actor_lv_gltest.c:154
-msgid "Transparant bars"
+msgid "Transparent bars"
 msgstr "Barras transparentes"
 
 #: plugins/actor/lv_scope/actor_lv_scope.c:68

--- a/libvisual-plugins/po/libvisual-plugins-0.4.pot
+++ b/libvisual-plugins/po/libvisual-plugins-0.4.pot
@@ -287,7 +287,7 @@ msgid "This plugin shows an openGL bar analyzer like the xmms one"
 msgstr ""
 
 #: plugins/actor/lv_gltest/actor_lv_gltest.c:154
-msgid "Transparant bars"
+msgid "Transparent bars"
 msgstr ""
 
 #: plugins/actor/lv_scope/actor_lv_scope.c:68

--- a/libvisual/README
+++ b/libvisual/README
@@ -15,7 +15,7 @@ libvisual can be drawn everywhere. That is but not limited
 to: ascii art, sdl, on gl object as a surface , alpha blended
 or just, anywhere.
 
-Libvisual also provides complete easy to use transparant
+Libvisual also provides complete easy to use transparent
 depth transformation, so that even when the display
 isn't supported by the plugin, libvisual will make
 it suite. Besides using libvisual for rendering your


### PR DESCRIPTION
> ```console
> git grep -l Transparant | xargs sed 's,Transparant,Transparent,g' -i
> git grep -l transparant | xargs sed 's,transparant,transparent,g' -i
> ```

Thanks to @eribertomota :+1: 