### PR TITLE
Core (LV::Singleton): Fix crash due to differing copies of singleton instances in LV and user programs

### DIFF
--- a/libvisual/libvisual/lv_singleton.hpp
+++ b/libvisual/libvisual/lv_singleton.hpp
@@ -1,6 +1,7 @@
 #ifndef _LV_SINGLETON_HPP
 #define _LV_SINGLETON_HPP
 
+#include <libvisual/lv_defines.h>
 #include <memory>
 
 namespace LV {
@@ -12,7 +13,7 @@ namespace LV {
   //! @note Singleton is implemented using the curiously recurring template pattern (CRTP).
   //!
   template <class T>
-  class Singleton
+  class LV_API Singleton
   {
   public:
 


### PR DESCRIPTION
The symbols `LV::System::m_instance` and `LV::PluginRegistry::m_instance` were not exported and this resulted in user programs and plugins having their own copies which remain uninitialized even after `LV::System::init()` or `LV::PluginRegistry::init()` was called.

Exporting the `LV::Singleton<T>` class template fixes the mysterious crashes.

The breakage first occurred in b4091ca.

@hartwork