### PR TITLE
[0.4.x] Replace broken Clang 17 CI with Clang 18

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -25,9 +25,9 @@ jobs:
             clang_major_version: 16
             clang_repo_suffix: -16
             runs-on: ubuntu-latest
-          - cc: clang-17
-            cxx: clang++-17
-            clang_major_version: 17
+          - cc: clang-18
+            cxx: clang++-18
+            clang_major_version: 18
             clang_repo_suffix:
             runs-on: ubuntu-latest
         # macOS


### PR DESCRIPTION
0.4.x version of #311

Related news entry:
> Jul 26th 2023 - Snapshot becomes 18, branch 17 created