### PR TITLE
`linux.yml`: Downgrade to GCC 12 to fix CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,13 +13,13 @@ env:
 jobs:
   linux:
     name: Build and test (Linux)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc-13
-            cxx: g++-13
+          - cc: gcc-12
+            cxx: g++-12
             clang_major_version: null
             clang_repo_suffix: null
           - cc: clang-18


### PR DESCRIPTION
.. because `ubuntu-22.04` suddenly dropped GCC 13.

Related:
- https://github.com/actions/runner-images/issues/9866
- https://github.com/actions/runner-images/issues/9679