### PR TITLE
[0.4.x] libvisual: fix accidental assignment instead of equality check

### DIFF
--- a/libvisual/libvisual/lv_hashmap.c
+++ b/libvisual/libvisual/lv_hashmap.c
@@ -261,7 +261,7 @@ static int get_hash (VisHashmap *hashmap, void *key, VisHashmapKeyType keytype)
 {
 	if (keytype == VISUAL_HASHMAP_KEY_TYPE_INTEGER)
 		return integer_hash (*((uint32_t *) key)) % hashmap->tablesize;
-	else if (keytype = VISUAL_HASHMAP_KEY_TYPE_STRING)
+	else if (keytype == VISUAL_HASHMAP_KEY_TYPE_STRING)
 		return string_hash ((char *) key) % hashmap->tablesize;
 
 	return 0;


### PR DESCRIPTION
with the accidental assignment, the function would always return 0 for a keytype of VISUAL_HASHMAP_KEY_TYPE_STRING (because it has a value of 2), which is technically valid but not good for obvious reasons
