### PR TITLE
[0.4.x] Stop patching `ax_check_gl.m4` for macOS

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -83,6 +83,8 @@ jobs:
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: |-
+          set -x
+          brew update
           brew install \
             autoconf-archive \
             automake \

--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -103,15 +103,6 @@ jobs:
             portaudio \
             sdl12-compat
 
-          # Patch ax_check_gl.m4 of autoconf-archive 2024.10.16 as needed
-          # https://github.com/Homebrew/homebrew-core/issues/202234
-          set -x -o pipefail
-          ax_check_gl_m4=/usr/local/Cellar/autoconf-archive/2024.10.16/share/aclocal/ax_check_gl.m4
-          if [[ -e "${ax_check_gl_m4}" ]] && ! grep -qF '[m4_fatal' "${ax_check_gl_m4}" ; then
-            wget -O- https://github.com/autoconf-archive/autoconf-archive/commit/427e226a2fe3980388abffd6de25ed6b9591cce3.patch \
-                | sudo patch -N "${ax_check_gl_m4}"
-          fi
-
       - name: Setting dynamic environment variables
         run: |-
           set -x


### PR DESCRIPTION
Homebrew started applying the patch itself by now: https://github.com/Homebrew/homebrew-core/pull/202309

This reverts commit 222b6c4d5e79807c7af06b633a902fdd83144e78 of pull request #374 .