### PR TITLE
Plugins (Blursk): Fix double free when Blursk is loaded multiple times.

### DIFF
--- a/libvisual-plugins/plugins/actor/blursk/blursk.c
+++ b/libvisual-plugins/plugins/actor/blursk/blursk.c
@@ -611,6 +611,7 @@ void __blursk_cleanup (BlurskPrivate *priv) {
     visual_mem_free(config.cpu_speed);
     visual_mem_free(config.show_info);
 
+    visual_mem_set(&config, 0, sizeof(config));
 }
 
 


### PR DESCRIPTION
Blursk crashes in `__blursk_cleanup` when the plugin is loaded and unloaded multiple times. This can occur when `lv-tool` cycles through actors and completes a full rotation.

The bug is due to the sharing and re-use of the variable `config` across instances.  

`config` contains multiple strings allocated during plugin instance initialization in `config_default()`:

```C
if(conf->color_style)
    visual_mem_free(conf->color_style);
conf->color_style = visual_strdup(config_default_color_style);
if(conf->signal_color)
    visual_mem_free(conf->signal_color);
conf->signal_color = visual_strdup(config_default_signal_color);
```

These strings are then freed in `__blursk_cleanup()` when the plugin instance is cleaned up.
```C
visual_mem_free(config.color_style);
visual_mem_free(config.signal_color);
```

After freeing the strings in the first instance, these pointer values remain unchanged and the next run of `config_default()` crashes the program.

The solution is to unshare the `config` struct but I ran into a header inclusion cycle with my attempt. Breaking the cycle requires a fair amount of refactoring, so I decided to instead zero out the `config` struct to complete the clean-up.

We can come back to this after a more thorough review of the plugin system.
