### PR TITLE
Change PNG image loader to load 8-bit indexed images without format conversion 

### DIFF
--- a/libvisual/tests/video_test/video_load_test.cpp
+++ b/libvisual/tests/video_test/video_load_test.cpp
@@ -102,11 +102,8 @@ namespace
                                               png_image->get_width (),
                                               png_image->get_height ())};
 
-      auto raw_image_rgb24 {LV::Video::create (raw_image->get_width (), raw_image->get_height (), VISUAL_VIDEO_DEPTH_24BIT)};
-      raw_image_rgb24->convert_depth (raw_image);
-
       LV_TEST_ASSERT (bmp_image->has_same_content (raw_image));
-      LV_TEST_ASSERT (png_image->has_same_content (raw_image_rgb24));
+      LV_TEST_ASSERT (png_image->has_same_content (raw_image));
   }
 
   void test_load_rgb24 ()


### PR DESCRIPTION
Currently, the PNG loader applies a libpng input transformation to convert 8-bit indexed colour images into 24-bit RGB images. This may be an undesirable step and inconsistent with what the BMP loader does.

This patch drops this and loads 8-bit indexed colour PNGs directly into 8-bit colour LV::Video objects. Note that 8-bit grayscale images continue to be converted to 24-bit RGB.