### PR TITLE
Fix BMP palette loading

### DIFF
--- a/libvisual/libvisual/lv_video.cpp
+++ b/libvisual/libvisual/lv_video.cpp
@@ -392,6 +392,10 @@ namespace LV {
           }
       }
 
+      // Videos must have the same palette.
+      if (m_impl->palette != video->m_impl->palette)
+          return false;
+
       return true;
   }
 

--- a/libvisual/libvisual/private/lv_video_bmp.cpp
+++ b/libvisual/libvisual/private/lv_video_bmp.cpp
@@ -341,7 +341,7 @@ namespace LV {
           return nullptr;
       }
 
-      if (bi_compression > 3) {
+      if (bi_compression >= 3) {
           visual_log (VISUAL_LOG_ERROR, "Bitmap uses an invalid or unsupported compression scheme");
           fp.seekg (saved_stream_pos);
           return nullptr;

--- a/libvisual/libvisual/private/lv_video_bmp.cpp
+++ b/libvisual/libvisual/private/lv_video_bmp.cpp
@@ -286,6 +286,8 @@ namespace LV {
       fp.read (reinterpret_cast<char*> (&bf_bits), 4);
       bf_bits = VISUAL_ENDIAN_LEI32 (bf_bits);
 
+      auto dib_header_pos = fp.tellg ();
+
       /* Read the info structure size */
       fp.read (reinterpret_cast<char*> (&bi_size), 4);
       bi_size = VISUAL_ENDIAN_LEI32 (bi_size);
@@ -346,6 +348,8 @@ namespace LV {
           fp.seekg (saved_stream_pos);
           return nullptr;
       }
+
+      fp.seekg (dib_header_pos + std::streampos {bi_size}, std::ios::beg);
 
       /* Load the palette */
       if (bi_bitcount < 24) {

--- a/libvisual/libvisual/private/lv_video_bmp.cpp
+++ b/libvisual/libvisual/private/lv_video_bmp.cpp
@@ -31,9 +31,12 @@
 #include <istream>
 #include <cstring>
 
-#define BI_RGB  0
-#define BI_RLE8 1
-#define BI_RLE4 2
+/* BMP compression methods */
+#define BI_RGB       0
+#define BI_RLE8      1
+#define BI_RLE4      2
+#define BI_BITFIELDS 3
+
 
 namespace LV {
 
@@ -343,7 +346,7 @@ namespace LV {
           return nullptr;
       }
 
-      if (bi_compression >= 3) {
+      if (bi_compression >= BI_BITFIELDS) {
           visual_log (VISUAL_LOG_ERROR, "Bitmap uses an invalid or unsupported compression scheme");
           fp.seekg (saved_stream_pos);
           return nullptr;

--- a/libvisual/libvisual/private/lv_video_bmp.cpp
+++ b/libvisual/libvisual/private/lv_video_bmp.cpp
@@ -352,9 +352,13 @@ namespace LV {
           return nullptr;
       }
 
+      /* Load the palette */
+
+      /* Skip past DIB header to color table */
+      /* BI_BITFIELDS and BI_ALPHABITFIELDS are unsupported, so there are
+         no bitmasks after the DIB header. */
       fp.seekg (dib_header_pos + std::streampos {bi_size}, std::ios::beg);
 
-      /* Load the palette */
       if (bi_bitcount < 24) {
           if (bi_clrused == 0) {
               /* When the colors used variable is zero, use the
@@ -391,6 +395,8 @@ namespace LV {
 
       if (palette)
           video->set_palette (*palette);
+
+      /* Read and decode image data */
 
       /* Set to the beginning of image data, note that MickeySoft likes stuff upside down .. */
       fp.seekg (bf_bits, std::ios::beg);


### PR DESCRIPTION
This PR fixes the palette loading in the BMP image loader.

The bug is due to the loader reading from the wrong file offset.

BMP files begin with a fixed size file header and a DIB (device-independent bitmap) header that has been continually extended over the years. According to [Wikipedia](https://en.wikipedia.org/wiki/BMP_file_format), there are 8 versions of the DIB header with differing sizes. They vary from the original 12 bytes to as large as 124 bytes in recent revisions. Each version subsumes the fields of previous versions. The colour table i.e. palette is found right after [1].

The loader currently reads part of the DIB header to get what it needs and proceeds to read the palette entries without accounting for the actual DIB header size. This patch fixes this by seeking to the end of the DIB header, utilizing the size given by the header's first field.

[1] Except when the compression schemes `BI_BITFIELDS` or `BI_ALPHABITFIELDS` are used, which isn't supported by the loader.
