### PR TITLE
[0.4.x] Accept sdl12-compat as SDL 1.2.x dependency

### DIFF
--- a/libvisual/configure.ac
+++ b/libvisual/configure.ac
@@ -405,7 +405,9 @@ if test  x$lv_tool_enabled = xyes -o x$examples = xyes ; then
   # Find SDL 1.x.x
   # On success, this will set and substitute SDL_CFLAGS and SDL_LIBS
   PKG_CHECK_MODULES([SDL], [sdl >= 1.2.0], [], [
-    AC_MSG_ERROR([*** SDL 1.2.x not installed - please install first])
+    PKG_CHECK_MODULES([SDL], [sdl12_compat], [], [
+      AC_MSG_ERROR([*** SDL 1.2.x not installed - please install first])
+    ])
   ])
   if test x$examples = xyes ; then
     AC_SUBST([EXAMPLES], ['simplesdl morphsdl'])


### PR DESCRIPTION
This makes it possible to build the examples and `lv-tool` on systems that do not provide SDL 1.2 but provide the compatibility layer.