### PR TITLE
[0.4.x] `linux_and_macos.yml`: Drop "brew update" to fix CI

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -83,7 +83,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |-
           set -x
-          brew update
           brew install \
             autoconf-archive \
             automake \


### PR DESCRIPTION
As of the moment, package `php` comes pre-installed and trying to apply mass-upgrades fails at `php`.