### PR TITLE
[0.4.x] CI: Stop using about-to-be-removed image "macos-13"

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -30,12 +30,12 @@ jobs:
             cxx: g++-13
             clang_major_version: null
             clang_repo_suffix: null
-            runs-on: macos-13
+            runs-on: macos-14
           - cc: clang
             cxx: clang++
             clang_major_version: null
             clang_repo_suffix: null
-            runs-on: macos-13
+            runs-on: macos-14
     steps:
       - name: Add Clang/LLVM repositories (Linux)
         if: "${{ runner.os == 'Linux' && contains(matrix.cxx, 'clang') }}"


### PR DESCRIPTION
> The macOS 13 runner image will be retired by December 4th, 2025.